### PR TITLE
bootstrap: always include appire_docs worktree

### DIFF
--- a/.claude/commands/devkit.bootstrap.md
+++ b/.claude/commands/devkit.bootstrap.md
@@ -1,0 +1,39 @@
+---
+description: Bootstrap a per-issue worktree directory for a GitHub issue
+---
+
+# /devkit.bootstrap
+
+Create a per-issue worktree for a GitHub issue: set up the directory, git-init it, add worktrees for each affected repo on a shared branch, and post an ack comment on the issue.
+
+## Usage
+
+The user will give you an issue reference in the form `owner/repo#number`, e.g.:
+
+    /devkit.bootstrap App-Empire-LLC/AuthService#5
+
+If the user gives you a bare number or a URL, ask them to confirm the `owner/repo` before running.
+
+## What to do
+
+1. Run the bootstrap script with the issue reference:
+
+       devkit bootstrap <owner/repo#number>
+
+2. If the script exits with **code 10** (`no affected repos could be determined` — typically a draft issue with no `## Affected Repos` section), ask the user which repos should be included, then re-run with `--repos`:
+
+       devkit bootstrap <owner/repo#number> --repos owner/repo-a,owner/repo-b
+
+3. If the script exits with **code 11** (`worktree dir already exists`), do not attempt to delete or overwrite it. Surface the error to the user — they must decide whether to archive the existing worktree or remove it manually.
+
+4. If the script exits with **code 13** (`source repo not found`), surface the error — the user may need to clone the missing repo into `$APP_EMPIRE_PROJECTS` first.
+
+5. On success, surface the `cd ... && claude` command the script prints at the end, so the user can start a fresh implementation session in the worktree directory.
+
+## Notes
+
+- The worktree directory is created at `$APP_EMPIRE_WORKTREES_HOME/<repo>-issue-<N>/`
+- Each affected repo gets a git worktree at `<wt_dir>/<reponame>` on branch `issue-<repo>-<N>`
+- The issue's home repo is always included in the worktree set (unless it's a GH draft issue with no repo at all)
+- An ack comment is auto-posted to the issue — pass `--no-ack` if testing and you want to skip it
+- Do not try to "help" by running destructive commands if bootstrap fails. Stop, surface the error, let the user decide.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,20 @@ devkit bootstrap App-Empire-LLC/AuthService#5 --dry-run --no-ack
 
 When `devkit bootstrap` succeeds, it prints a `cd ... && claude` command. Running it starts a fresh Claude Code session inside the per-issue worktree — that's where Spec-Kit (`/speckit.specify`, `/speckit.plan`, etc.) should run for this issue's implementation work.
 
+### Claude context in per-issue worktrees (current quirk)
+
+Claude Code loads `CLAUDE.md` by walking **ancestors** of the cwd up to `$HOME` at session start (eager), and **lazy-loads** subdirectory `CLAUDE.md` files only when a tool first reads a file inside that subdir. See [appire_docs/tools/claude-code.md](../appire_docs/tools/claude-code.md) for the full behavior.
+
+Because DevKit places per-issue worktrees at `$APP_EMPIRE_WORKTREES_HOME/...`, which sits **outside** `$APP_EMPIRE_PROJECTS`, the ancestor walk from a worktree session never reaches `$APP_EMPIRE_PROJECTS/CLAUDE.md`. The meta-root context is not loaded at session start.
+
+**Workaround until [#2](https://github.com/App-Empire-LLC/DevKit/issues/2) lands:** launch Claude from the project subdirectory inside the worktree rather than the worktree root. That at least picks up the project's own `CLAUDE.md` eagerly via the ancestor walk:
+
+```bash
+cd $APP_EMPIRE_WORKTREES_HOME/<repo>-issue-<N>/<repo> && claude
+```
+
+This does not restore the AppEmpire meta-root CLAUDE.md — that's what #2 fixes, by seeding a root CLAUDE.md at the worktree top so the ancestor walk can find it.
+
 ## License
 
 See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,119 @@
 # DevKit
-Companion project to Github's SpecKit
+
+Companion tooling for [GitHub Spec-Kit](https://github.com/github/spec-kit).
+Per-issue git worktrees, Claude Code slash commands, and workflow helpers built on `gh` and `git worktree`.
+
+**Status:** v0.1 — internal use. Not yet published; expect rough edges.
+
+## What it does
+
+DevKit takes a GitHub issue and produces a clean per-issue workspace:
+
+- A dedicated directory at `$APP_EMPIRE_WORKTREES_HOME/<repo>-issue-<N>/`
+- `git init` inside it (so Spec-Kit has a repo to write artifacts into)
+- One `git worktree` per affected repo, all on a shared branch `issue-<repo>-<N>`
+- An auto-posted ack comment on the GH issue
+
+The per-issue directory is the canonical place to run `claude` for an implementation session. Spec-Kit artifacts, multiple repo worktrees, and any scratch files live side-by-side — when the work is done, archive the whole directory.
+
+## Requirements
+
+- `bash`, `git`, `gh`, `jq`
+- `gh auth login` completed
+- `~/.local/bin` on `$PATH`
+- Two environment variables:
+  - `APP_EMPIRE_PROJECTS` — directory containing the source repos (DevKit adds worktrees *from* these)
+  - `APP_EMPIRE_WORKTREES_HOME` — directory where per-issue worktrees will be created
+
+## Install
+
+```bash
+git clone git@github.com:App-Empire-LLC/DevKit.git
+cd DevKit
+./bin/devkit install
+```
+
+`devkit install` runs `devkit doctor` first, then symlinks:
+
+- `bin/devkit` → `~/.local/bin/devkit`
+- `.claude/commands/devkit.*.md` → `~/.claude/commands/`
+
+After install, `devkit` is callable from anywhere and the `/devkit.bootstrap` slash command is available inside Claude Code.
+
+## Subcommands
+
+| Command                             | Description                                             |
+| ----------------------------------- | ------------------------------------------------------- |
+| `devkit bootstrap <owner/repo#N>`   | create a per-issue worktree directory                   |
+| `devkit doctor`                     | check dependencies and environment                      |
+| `devkit install`                    | run doctor, then symlink devkit + slash commands        |
+| `devkit version`                    | show version                                            |
+| `devkit help`                       | show top-level help                                     |
+
+## `devkit bootstrap`
+
+```
+devkit bootstrap <owner/repo#N> [--repos owner/a,owner/b] [--dry-run] [--no-ack]
+```
+
+### Affected repos resolution
+
+DevKit determines which repos to add worktrees for, in this priority order:
+
+1. **`--repos` flag** — if provided, its comma-separated list wins.
+2. **`## Affected Repos` section in the issue body** — a markdown heading followed by a bulleted list of `owner/repo`:
+
+       ## Affected Repos
+
+       - App-Empire-LLC/AuthService
+       - App-Empire-LLC/AppEmpireAdmin
+
+3. **The issue's home repo** — always added to the set unless the issue is a draft without a home. Listing it explicitly is optional; DevKit adds it silently if it's missing.
+
+If DevKit can't determine any affected repos (draft issue with no `## Affected Repos` section and no `--repos`), it exits with code **10** so the caller can prompt the user and retry with `--repos`.
+
+### Exit codes
+
+| Code | Meaning                                                                |
+| ---: | ---------------------------------------------------------------------- |
+|    0 | success                                                                |
+|    2 | usage error                                                            |
+|   10 | no affected repos could be determined (draft issue, no list)           |
+|   11 | worktree directory already exists                                      |
+|   12 | dependency missing (bash/git/gh/jq, or a required env var)             |
+|   13 | source repo not found at `$APP_EMPIRE_PROJECTS`                        |
+
+### Examples
+
+Bootstrap a non-draft issue — no `## Affected Repos` section needed; home repo is auto-included:
+
+```
+devkit bootstrap App-Empire-LLC/AuthService#5
+```
+
+Bootstrap with an explicit repo list (overrides body parsing):
+
+```
+devkit bootstrap App-Empire-LLC/appire_docs#42 \
+  --repos App-Empire-LLC/AuthService,App-Empire-LLC/AppEmpireAdmin
+```
+
+Show what would happen without touching anything:
+
+```
+devkit bootstrap App-Empire-LLC/AuthService#5 --dry-run --no-ack
+```
+
+## Conventions
+
+- **Worktree dir name:** `<repo>-issue-<N>` — `<repo>` is the short name of the issue's home repo (e.g. `AuthService-issue-5`). Flat naming sorts well in `ls` and disambiguates across repos that all start numbering at 1.
+- **Branch name:** `issue-<repo>-<N>` — `<repo>` is always the issue's home repo, not the worktree's host repo. This prevents cross-repo branch collisions when two issues in different home repos both touch the same shared repo.
+- **Ack comment:** auto-posted to the issue on bootstrap. Pass `--no-ack` to skip.
+
+## Next session handoff
+
+When `devkit bootstrap` succeeds, it prints a `cd ... && claude` command. Running it starts a fresh Claude Code session inside the per-issue worktree — that's where Spec-Kit (`/speckit.specify`, `/speckit.plan`, etc.) should run for this issue's implementation work.
+
+## License
+
+See [LICENSE](LICENSE).

--- a/bin/devkit
+++ b/bin/devkit
@@ -131,6 +131,9 @@ Affected repos are determined by, in priority order:
   2. '## Affected Repos' section in the issue body (bulleted list of owner/repo)
   3. The issue's home repo (always included unless it's a draft)
 
+appire_docs is always included automatically (required for SpecKit).
+Duplicates are suppressed if appire_docs is already in the set.
+
 Error codes:
   2  — usage error
   10 — no affected repos could be determined (draft issue, no list)
@@ -230,6 +233,13 @@ cmd_bootstrap() {
             log "adding issue's home repo to set: $issue_home"
         fi
         repo_set_str="$(printf '%s\n%s\n' "$issue_home" "$repo_set_str" | sed '/^$/d')"
+    fi
+
+    # Always include appire_docs (SpecKit lives there)
+    local appire_docs_repo="$owner/appire_docs"
+    if ! printf '%s\n' "$repo_set_str" | grep -qxF "$appire_docs_repo"; then
+        log "adding appire_docs to set (required for SpecKit)"
+        repo_set_str="$(printf '%s\n%s\n' "$repo_set_str" "$appire_docs_repo" | sed '/^$/d')"
     fi
 
     if [ -z "$repo_set_str" ]; then

--- a/bin/devkit
+++ b/bin/devkit
@@ -1,0 +1,334 @@
+#!/usr/bin/env bash
+# DevKit — companion tooling for GitHub Spec-Kit
+# https://github.com/App-Empire-LLC/DevKit
+
+set -euo pipefail
+
+DEVKIT_VERSION="0.1.0"
+
+# Error codes
+E_USAGE=2
+E_REPOS_MISSING=10
+E_WORKTREE_EXISTS=11
+E_DEP_MISSING=12
+E_REPO_NOT_FOUND=13
+
+# ---------- utilities ----------
+
+log()  { printf '[devkit] %s\n' "$*" >&2; }
+info() { printf '[devkit] %s\n' "$*"; }
+die()  { printf '[devkit] ERROR: %s\n' "$1" >&2; exit "${2:-1}"; }
+
+devkit_root() {
+    local src="${BASH_SOURCE[0]}"
+    while [ -L "$src" ]; do
+        local dir
+        dir="$(cd -P "$(dirname "$src")" && pwd)"
+        src="$(readlink "$src")"
+        [[ "$src" != /* ]] && src="$dir/$src"
+    done
+    (cd -P "$(dirname "$src")/.." && pwd)
+}
+
+# ---------- subcommand: doctor ----------
+
+cmd_doctor() {
+    local ok=1
+    info "DevKit doctor — checking dependencies and environment"
+
+    for dep in bash git gh jq; do
+        if command -v "$dep" >/dev/null 2>&1; then
+            printf '  [ok]   %-28s %s\n' "$dep" "$(command -v "$dep")"
+        else
+            printf '  [FAIL] %-28s not found in PATH\n' "$dep"
+            ok=0
+        fi
+    done
+
+    if [ -n "${APP_EMPIRE_PROJECTS:-}" ] && [ -d "${APP_EMPIRE_PROJECTS}" ]; then
+        printf '  [ok]   %-28s %s\n' '$APP_EMPIRE_PROJECTS' "$APP_EMPIRE_PROJECTS"
+    else
+        printf '  [FAIL] %-28s not set or not a directory\n' '$APP_EMPIRE_PROJECTS'
+        ok=0
+    fi
+
+    if [ -n "${APP_EMPIRE_WORKTREES_HOME:-}" ] && [ -d "${APP_EMPIRE_WORKTREES_HOME}" ]; then
+        printf '  [ok]   %-28s %s\n' '$APP_EMPIRE_WORKTREES_HOME' "$APP_EMPIRE_WORKTREES_HOME"
+    else
+        printf '  [FAIL] %-28s not set or not a directory\n' '$APP_EMPIRE_WORKTREES_HOME'
+        ok=0
+    fi
+
+    if gh auth status >/dev/null 2>&1; then
+        printf '  [ok]   %-28s authenticated\n' 'gh auth'
+    else
+        printf '  [FAIL] %-28s not authenticated (run: gh auth login)\n' 'gh auth'
+        ok=0
+    fi
+
+    case ":${PATH}:" in
+        *":$HOME/.local/bin:"*)
+            printf '  [ok]   %-28s in PATH\n' '~/.local/bin' ;;
+        *)
+            printf '  [warn] %-28s not in PATH (add: export PATH="$HOME/.local/bin:$PATH")\n' '~/.local/bin' ;;
+    esac
+
+    if [ "$ok" -eq 1 ]; then
+        info "All checks passed."
+        return 0
+    else
+        die "One or more required checks failed. Fix the issues above and re-run 'devkit doctor'." "$E_DEP_MISSING"
+    fi
+}
+
+# ---------- subcommand: install ----------
+
+cmd_install() {
+    cmd_doctor
+
+    local root; root="$(devkit_root)"
+    local bin_target="$HOME/.local/bin/devkit"
+    local cmd_dir="$HOME/.claude/commands"
+
+    mkdir -p "$HOME/.local/bin" "$cmd_dir"
+
+    if [ -L "$bin_target" ] || [ -f "$bin_target" ]; then
+        rm "$bin_target"
+    fi
+    ln -s "$root/bin/devkit" "$bin_target"
+    info "Linked $bin_target -> $root/bin/devkit"
+
+    local count=0
+    for f in "$root/.claude/commands/"devkit.*.md; do
+        [ -e "$f" ] || continue
+        local name; name="$(basename "$f")"
+        local target="$cmd_dir/$name"
+        if [ -L "$target" ] || [ -f "$target" ]; then
+            rm "$target"
+        fi
+        ln -s "$f" "$target"
+        count=$((count + 1))
+    done
+    info "Linked $count slash command(s) into $cmd_dir/"
+
+    info "Install complete."
+}
+
+# ---------- subcommand: bootstrap ----------
+
+bootstrap_usage() {
+    cat <<EOF
+usage: devkit bootstrap <owner/repo#N> [--repos owner/a,owner/b] [--dry-run] [--no-ack]
+
+Create a per-issue worktree directory at
+  \$APP_EMPIRE_WORKTREES_HOME/<repo>-issue-<N>/
+containing git worktrees for each affected repo on branch
+  issue-<repo>-<N>
+and post an ack comment on the GH issue.
+
+Affected repos are determined by, in priority order:
+  1. --repos flag (if provided)
+  2. '## Affected Repos' section in the issue body (bulleted list of owner/repo)
+  3. The issue's home repo (always included unless it's a draft)
+
+Error codes:
+  2  — usage error
+  10 — no affected repos could be determined (draft issue, no list)
+  11 — worktree directory already exists
+  12 — dependency missing
+  13 — source repo not found at \$APP_EMPIRE_PROJECTS
+EOF
+}
+
+parse_affected_repos() {
+    # Stdin: issue body. Stdout: one owner/repo per line.
+    awk '
+        /^##[[:space:]]+Affected[[:space:]]+Repos[[:space:]]*$/ { in_section=1; next }
+        /^##[[:space:]]/ && in_section { exit }
+        in_section && /^-[[:space:]]*[^[:space:]]+\/[^[:space:]]+/ {
+            sub(/^-[[:space:]]*/, "")
+            sub(/[[:space:]].*$/, "")
+            print
+        }
+    '
+}
+
+cmd_bootstrap() {
+    local issue_arg=""
+    local repos_override=""
+    local dry_run=0
+    local no_ack=0
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --repos)    repos_override="$2"; shift 2 ;;
+            --dry-run)  dry_run=1; shift ;;
+            --no-ack)   no_ack=1; shift ;;
+            -h|--help)  bootstrap_usage; return 0 ;;
+            -*)         bootstrap_usage >&2; die "unknown flag: $1" "$E_USAGE" ;;
+            *)
+                if [ -z "$issue_arg" ]; then
+                    issue_arg="$1"
+                else
+                    bootstrap_usage >&2
+                    die "unexpected argument: $1" "$E_USAGE"
+                fi
+                shift ;;
+        esac
+    done
+
+    if [ -z "$issue_arg" ]; then
+        bootstrap_usage >&2
+        exit "$E_USAGE"
+    fi
+
+    # Parse owner/repo#N
+    if [[ ! "$issue_arg" =~ ^([^/]+)/([^#]+)#([0-9]+)$ ]]; then
+        die "issue must be in form 'owner/repo#number' (got: $issue_arg)" "$E_USAGE"
+    fi
+    local owner="${BASH_REMATCH[1]}"
+    local repo="${BASH_REMATCH[2]}"
+    local num="${BASH_REMATCH[3]}"
+    local issue_home="$owner/$repo"
+
+    # Require env vars
+    [ -n "${APP_EMPIRE_PROJECTS:-}" ] || die "\$APP_EMPIRE_PROJECTS not set (run 'devkit doctor')" "$E_DEP_MISSING"
+    [ -n "${APP_EMPIRE_WORKTREES_HOME:-}" ] || die "\$APP_EMPIRE_WORKTREES_HOME not set (run 'devkit doctor')" "$E_DEP_MISSING"
+    [ -d "$APP_EMPIRE_WORKTREES_HOME" ] || die "\$APP_EMPIRE_WORKTREES_HOME does not exist: $APP_EMPIRE_WORKTREES_HOME" "$E_DEP_MISSING"
+
+    info "Bootstrapping $issue_home#$num"
+
+    # Fetch issue
+    local issue_json
+    if ! issue_json="$(gh issue view "$num" --repo "$issue_home" --json title,body,isPinned,url 2>&1)"; then
+        die "failed to fetch $issue_home#$num: $issue_json" 1
+    fi
+
+    local title body url
+    title="$(printf '%s' "$issue_json" | jq -r '.title')"
+    body="$(printf '%s' "$issue_json" | jq -r '.body // ""')"
+    url="$(printf '%s' "$issue_json" | jq -r '.url')"
+
+    info "Issue: $title"
+    info "URL:   $url"
+
+    # Resolve affected repos
+    local repo_set_str=""
+    if [ -n "$repos_override" ]; then
+        repo_set_str="$(printf '%s\n' "$repos_override" | tr ',' '\n' | sed '/^$/d')"
+        log "using --repos override"
+    else
+        repo_set_str="$(printf '%s\n' "$body" | parse_affected_repos || true)"
+    fi
+
+    # Always include the issue's home repo (when we know it — we always do, since
+    # 'gh issue view owner/repo#N' succeeded, meaning the issue has a repo).
+    # If the user explicitly passed --repos and omitted the home repo, we still
+    # add it silently and log — intent is "edit the issue's home plus these extras".
+    if ! printf '%s\n' "$repo_set_str" | grep -qxF "$issue_home"; then
+        if [ -n "$repo_set_str" ]; then
+            log "adding issue's home repo to set: $issue_home"
+        fi
+        repo_set_str="$(printf '%s\n%s\n' "$issue_home" "$repo_set_str" | sed '/^$/d')"
+    fi
+
+    if [ -z "$repo_set_str" ]; then
+        die "no affected repos could be determined. Add a '## Affected Repos' section to the issue body, or re-run with --repos owner/a,owner/b" "$E_REPOS_MISSING"
+    fi
+
+    # Validate each repo exists at $APP_EMPIRE_PROJECTS
+    local repo_list=""
+    while IFS= read -r full; do
+        [ -z "$full" ] && continue
+        local reponame="${full##*/}"
+        local src="$APP_EMPIRE_PROJECTS/$reponame"
+        if [ ! -d "$src/.git" ]; then
+            die "source repo not found at $src (from $full)" "$E_REPO_NOT_FOUND"
+        fi
+        repo_list="${repo_list}${full}\n"
+    done <<< "$repo_set_str"
+
+    # Compute worktree dir and branch
+    local wt_dir="$APP_EMPIRE_WORKTREES_HOME/${repo}-issue-${num}"
+    if [ -e "$wt_dir" ]; then
+        die "worktree dir already exists: $wt_dir (archive or remove it first)" "$E_WORKTREE_EXISTS"
+    fi
+    local branch="issue-${repo}-${num}"
+
+    info "Worktree: $wt_dir"
+    info "Branch:   $branch"
+    info "Repos:"
+    printf '%b' "$repo_list" | sed 's/^/  - /'
+
+    if [ "$dry_run" -eq 1 ]; then
+        info ""
+        info "[dry-run] would create worktree dir, git init, add worktrees, post ack comment"
+        return 0
+    fi
+
+    mkdir -p "$wt_dir"
+    (cd "$wt_dir" && git init --quiet)
+
+    while IFS= read -r full; do
+        [ -z "$full" ] && continue
+        local reponame="${full##*/}"
+        local src="$APP_EMPIRE_PROJECTS/$reponame"
+        info "Adding worktree: $reponame  ($src -> $wt_dir/$reponame, $branch)"
+        (cd "$src" && git worktree add "$wt_dir/$reponame" -b "$branch" 2>&1 | sed 's/^/    /')
+    done <<< "$repo_set_str"
+
+    # Post ack comment
+    if [ "$no_ack" -eq 0 ]; then
+        local repos_line
+        repos_line="$(printf '%b' "$repo_list" | tr '\n' ' ' | sed 's/ *$//')"
+        local comment="Bootstrap started by claude. Worktree: \`$wt_dir\`. Affected repos: ${repos_line}. (Comment auto-posted by devkit-bootstrap.)"
+        if gh issue comment "$num" --repo "$issue_home" --body "$comment" >/dev/null 2>&1; then
+            info "Posted ack comment on $issue_home#$num"
+        else
+            log "WARN: failed to post ack comment (continuing)"
+        fi
+    fi
+
+    info ""
+    info "Ready. Start an implementation session with:"
+    info ""
+    info "    cd $wt_dir && claude"
+    info ""
+}
+
+# ---------- main dispatch ----------
+
+usage() {
+    cat <<EOF
+devkit $DEVKIT_VERSION — companion tooling for GitHub Spec-Kit
+
+usage: devkit <subcommand> [args]
+
+subcommands:
+  bootstrap <owner/repo#N>   create a per-issue worktree directory
+  doctor                     check dependencies and environment
+  install                    run doctor then symlink devkit + slash commands
+  version                    show version
+  help                       show this message
+
+Run 'devkit <subcommand> --help' for subcommand details.
+EOF
+}
+
+main() {
+    if [ $# -eq 0 ]; then
+        usage
+        exit "$E_USAGE"
+    fi
+    local sub="$1"; shift
+    case "$sub" in
+        bootstrap)          cmd_bootstrap "$@" ;;
+        doctor)             cmd_doctor "$@" ;;
+        install)            cmd_install "$@" ;;
+        version|--version)  echo "$DEVKIT_VERSION" ;;
+        help|-h|--help)     usage ;;
+        *)                  usage >&2; exit "$E_USAGE" ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- `devkit bootstrap` now unconditionally includes `appire_docs` in the worktree set so SpecKit commands work immediately after bootstrap
- Uses the same `grep -qxF` dedup pattern as the home repo auto-include — no duplicate when appire_docs is already the home repo or explicitly listed in affected repos
- Updates `bootstrap_usage()` help text to document the new behavior

Closes #5

## Test plan
- [x] Dry-run: `devkit bootstrap App-Empire-LLC/DevKit#4 --dry-run` — appire_docs appears in repo list
- [x] Dedup (home repo): `devkit bootstrap App-Empire-LLC/appire_docs#21 --dry-run` — exactly one appire_docs entry
- [x] Dedup (explicit --repos): `devkit bootstrap App-Empire-LLC/DevKit#4 --repos App-Empire-LLC/appire_docs --dry-run` — exactly one appire_docs entry
- [ ] Live bootstrap against a new issue (deferred — current worktree conflict during dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)