### PR TITLE
hermeticity: fix guard global-bleed + detect src/ bypass

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,14 @@ line-length = 100
 target-version = "py311"
 
 [tool.ruff.lint]
-select = ["E", "F", "I"]
+select = ["E", "F", "I", "TID251"]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"subprocess".msg = "Don't import subprocess directly in src/aidevkit/. Use aidevkit.util.run (see tests/conftest.py::_fail_on_unmocked_shell for the hermeticity rationale)."
+
+[tool.ruff.lint.per-file-ignores]
+"src/aidevkit/util.py" = ["TID251"]
+"tests/**" = ["TID251"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/aidevkit/util.py
+++ b/src/aidevkit/util.py
@@ -48,8 +48,25 @@ class RunResult:
     stderr: str
 
 
+class _Runner:
+    """Instance-scoped wrapper around subprocess.run.
+
+    The hermeticity guard in tests/conftest.py patches this instance's `run`
+    attribute. Using an instance method instead of a module-level reference to
+    subprocess.run prevents the patch from leaking into the global subprocess
+    module — integration-test fixtures that call subprocess.run directly are
+    unaffected.
+    """
+
+    def run(self, *args, **kwargs):
+        return subprocess.run(*args, **kwargs)
+
+
+_runner = _Runner()
+
+
 def run(cmd: list[str], *, check: bool = False, cwd: Optional[Path] = None) -> RunResult:
-    proc = subprocess.run(
+    proc = _runner.run(
         cmd,
         cwd=cwd,
         capture_output=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,12 @@
 
 Hermeticity contract: no test is permitted to invoke real `git` or `gh` against
 real repositories or the real GitHub API. The autouse `_fail_on_unmocked_shell`
-fixture enforces this by patching `aidevkit.util.subprocess.run` — the single
-import site of `subprocess` in DevKit — so any bypass of the `util.run` seam
-surfaces as a loud `RuntimeError`.
+fixture enforces this by patching `aidevkit.util._runner.run` — the
+instance-scoped shell seam introduced for DevKit#29 — so any bypass of the
+`util.run` wrapper surfaces as a loud `RuntimeError`. Patching the instance
+(rather than a module-level `subprocess.run` reference) keeps the guard
+isolated from the global `subprocess` module; integration-test fixtures that
+call `subprocess.run` directly are unaffected.
 """
 from __future__ import annotations
 
@@ -96,18 +99,33 @@ def gh_response() -> Callable[[str], dict[str, Any]]:
 
 
 @pytest.fixture(autouse=True)
-def _fail_on_unmocked_shell(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Hermeticity guard: any real `subprocess.run` call via `util` is a violation.
+def _fail_on_unmocked_shell(
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hermeticity guard: any real shell call via `util` is a violation.
 
     Fires when `_CAPTURE_ACTIVE` is False (no `subprocess_capture` in use) —
     this surfaces tests that trigger `util.run` without having installed the
     fixture. When `_CAPTURE_ACTIVE` is True, this still fires if something
-    bypassed the `util.run` seam and reached `subprocess.run` directly.
+    bypassed the `util.run` seam and reached the runner directly.
+
+    Scope: unit tests only. Integration tests under `tests/integration/` drive
+    the real `git` binary against tempdir fixtures and legitimately route
+    through `util.run`, so the guard is not installed there. (Per DevKit#29,
+    this replaces the tree-wide no-op override that previously lived in
+    `tests/integration/conftest.py`.)
+
+    Patches `aidevkit.util._runner.run` (instance attribute) rather than the
+    global `subprocess.run` — see module docstring.
     """
+    if any(part == "integration" for part in request.node.path.parts):
+        return
+
     def guard(*args: Any, **kwargs: Any) -> None:
         if _CAPTURE_ACTIVE:
             raise RuntimeError(
-                "hermeticity violation: util.subprocess.run invoked despite "
+                "hermeticity violation: util._runner.run invoked despite "
                 "subprocess_capture being active — something bypassed the util.run seam"
             )
         raise RuntimeError(
@@ -115,4 +133,4 @@ def _fail_on_unmocked_shell(monkeypatch: pytest.MonkeyPatch) -> None:
             "fixture active"
         )
 
-    monkeypatch.setattr("aidevkit.util.subprocess.run", guard)
+    monkeypatch.setattr("aidevkit.util._runner.run", guard)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -113,18 +113,6 @@ class FakeWorkspace:
             (self.workspace_root / scope / "TRUNK.md").write_text(f"{value}\n")
 
 
-@pytest.fixture(autouse=True)
-def _fail_on_unmocked_shell() -> None:
-    """Override the top-level hermeticity guard for integration tests.
-
-    Integration tests drive the real `git` binary against tempdir fixtures —
-    that's the point. The parent autouse guard in `tests/conftest.py` exists
-    to catch unit tests that forget `subprocess_capture`; it's not applicable
-    here.
-    """
-    return
-
-
 @pytest.fixture
 def fake_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> FakeWorkspace:
     """Two repos, two origins, one workspace with two worktrees on `issue-<repo>-42`."""

--- a/tests/test_hermeticity_structure.py
+++ b/tests/test_hermeticity_structure.py
@@ -1,0 +1,46 @@
+"""Structural backup detector for FR-005 / DevKit#29.
+
+Walks every `src/aidevkit/**/*.py` file, collects all top-level and nested
+`import subprocess` / `from subprocess import ...` statements, and fails if
+any live outside the designated seam (`src/aidevkit/util.py`).
+
+This is a belt-and-suspenders check complementing the ruff TID251 rule
+configured in `pyproject.toml`. If the lint rule ever gets disabled or
+misconfigured, this test still fails on a direct-subprocess bypass.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / "aidevkit"
+SEAM = SRC_ROOT / "util.py"
+
+
+def _uses_subprocess(node: ast.AST) -> bool:
+    if isinstance(node, ast.Import):
+        return any(
+            alias.name == "subprocess" or alias.name.startswith("subprocess.")
+            for alias in node.names
+        )
+    if isinstance(node, ast.ImportFrom):
+        mod = node.module or ""
+        return mod == "subprocess" or mod.startswith("subprocess.")
+    return False
+
+
+def test_no_subprocess_imports_outside_seam() -> None:
+    violations: list[tuple[str, int]] = []
+    for py_file in SRC_ROOT.rglob("*.py"):
+        if py_file.resolve() == SEAM.resolve():
+            continue
+        tree = ast.parse(py_file.read_text(), filename=str(py_file))
+        for node in ast.walk(tree):
+            if _uses_subprocess(node):
+                rel = py_file.relative_to(SRC_ROOT.parent.parent)
+                violations.append((str(rel), node.lineno))
+    assert not violations, (
+        f"Hermeticity violation: {len(violations)} file(s) import `subprocess` outside the seam "
+        f"({SEAM.relative_to(SRC_ROOT.parent.parent)}). Use aidevkit.util.run instead.\n"
+        f"Violations: {violations}"
+    )

--- a/tests/test_runner_scope.py
+++ b/tests/test_runner_scope.py
@@ -1,0 +1,30 @@
+"""Regression guard for SC-005 / FR-001: runner-scope isolation.
+
+Patching `aidevkit.util._runner.run` must affect `util.run` callers but MUST
+NOT leak into the global `subprocess` module. If a future refactor ever
+reverts to patching `aidevkit.util.subprocess.run` (module-global), direct
+`subprocess.run` callers would start failing — and this test would catch it.
+"""
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from aidevkit import util
+
+
+def test_runner_scope_is_isolated_from_global_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail(*args, **kwargs):
+        raise RuntimeError("runner-scoped stub fired")
+
+    monkeypatch.setattr("aidevkit.util._runner.run", fail)
+
+    with pytest.raises(RuntimeError, match="runner-scoped stub fired"):
+        util.run(["echo", "hi"])
+
+    proc = subprocess.run(["echo", "direct-ok"], capture_output=True, text=True)
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == "direct-ok"


### PR DESCRIPTION
## Summary

Closes #29. Two-part fix for the hermeticity guard:

1. **Runner seam refactor.** `aidevkit.util` now routes subprocess calls through an instance-scoped `_Runner` object. The autouse guard in `tests/conftest.py` patches `util._runner.run` (an instance attribute), not `util.subprocess.run` (a module global whose mutation leaked into `subprocess.run` worldwide). Integration fixture setup via `subprocess.run` is no longer affected by the guard.

2. **Unit-test scoping of the guard.** The guard's autouse fixture now checks `request.node.path` and returns early for tests under `tests/integration/`. This replaces the tree-wide `_fail_on_unmocked_shell` no-op override that previously lived in `tests/integration/conftest.py` — integration tests get the real runner behavior by default, no opt-out boilerplate required.

3. **Structural detector for bypasses.** New ruff `TID251` rule (with `per-file-ignores` for `src/aidevkit/util.py` and `tests/**`) and a belt-and-suspenders `tests/test_hermeticity_structure.py` (stdlib `ast` walk of `src/aidevkit/**/*.py`) catch any future `src/` module that imports `subprocess` directly.

4. **Runner-scope regression test.** `tests/test_runner_scope.py` asserts that patching `_runner.run` does not leak to `subprocess.run` — codifies the no-global-bleed invariant as an automated check.

## Test plan

- [x] 70 existing tests continue to pass (no regressions)
- [x] 2 new tests pass (`test_runner_scope`, `test_hermeticity_structure`) — 72 total
- [x] `ruff check` clean
- [x] Integration tests pass without any `_fail_on_unmocked_shell` override
- [x] Smoke test: unit test calling `util.run` without `subprocess_capture` still fires the guard
- [x] Synthetic `src/aidevkit/_smoke_bypass.py` flagged by both `ruff check` and `test_hermeticity_structure`
- [x] Seam (`src/aidevkit/util.py`) not flagged by either detector

## Notes

Implementation discovered that instance-scoping alone was insufficient — integration tests also exercise the code-under-test (`devkit sync`) which legitimately calls `util.run`. Added the unit-test path scope check to the guard as a single-line fix. Satisfies spec FR-004 since no guard code lives in `tests/integration/conftest.py`.

Known gap (documented in spec): dynamic imports like `importlib.import_module("subprocess")` are not caught by either static detector. Acknowledged; out of scope for this feature.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>