### PR TITLE
feat: lifecycle + self-management commands (v0.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,20 @@ Runs `devkit doctor` first, then symlinks `~/.claude/commands/devkit.*.md` → t
 | ----------------------------------- | ------------------------------------------------------- |
 | `devkit bootstrap <owner/repo#N>`   | create a per-issue worktree directory                   |
 | `devkit sync`                       | fetch and rebase every worktree in the current workspace onto its trunk |
+| `devkit status [--json]`            | summarize every active per-issue workspace (issue state, branches, PRs) |
+| `devkit add-repo <name>`            | add a sibling repo's worktree to the current per-issue workspace |
+| `devkit archive <owner/repo#N>`     | post spec to issue, move workspace to `_archived/`, prune worktrees |
+| `devkit purge [--days N] [--yes]`   | delete archived workspaces older than the retention threshold |
+| `devkit preflight`                  | detect whether the current issue branch is behind `origin/main` |
 | `devkit doctor`                     | check dependencies and environment                      |
 | `devkit setup`                      | link slash commands into `~/.claude/commands/` (runs doctor first) |
+| `devkit uninstall`                  | remove DevKit: unlink slash commands and `uv tool uninstall aidevkit` |
+| `devkit update`                     | `uv tool upgrade aidevkit` then run `devkit doctor`     |
+| `devkit check-update [--json]`      | non-destructive check for a newer `aidevkit` release    |
 | `devkit version`                    | show version                                            |
 | `devkit --help`                     | show top-level help (Typer auto-generated)              |
+
+Slash-command wrappers for the workflow primitives (`bootstrap`, `sync`, `status`, `add-repo`, `archive`, `purge`, `preflight`) are installed by `devkit setup` into `~/.claude/commands/devkit.<name>.md`. The self-management commands (`uninstall`, `update`, `check-update`) have no slash wrappers — they're meant to be run outside a per-issue session.
 
 ## `devkit bootstrap`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aidevkit"
-version = "0.2.0"
+version = "0.3.0"
 description = "Companion tooling for GitHub Spec-Kit — per-issue git worktrees, Claude Code slash commands, and workflow helpers."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/aidevkit/_install.py
+++ b/src/aidevkit/_install.py
@@ -1,0 +1,95 @@
+"""Install-method detection for self-management commands.
+
+Determines whether the running `aidevkit` was installed via `uv tool install`
+(manageable), `pip` / source checkout (not manageable by DevKit), or an
+unknown method. Used by `uninstall`, `update`, and `check-update` to decide
+whether to proceed or print guidance per FR-SELF-010.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, Optional
+
+from . import util
+
+Method = Literal["uv-tool", "pip", "source", "unknown"]
+
+_UV_TOOL_ENTRY_RE = re.compile(r"^([A-Za-z0-9_.-]+)\s+v?([0-9][^\s]*)")
+
+
+@dataclass
+class InstallInfo:
+    method: Method
+    installed_version: Optional[str]
+    tool_venv_path: Optional[Path]
+    manageable: bool
+
+
+def _parse_uv_tool_list(text: str, package: str) -> Optional[str]:
+    """Parse `uv tool list` output for `<package> v<version>`.
+
+    `uv tool list` lines look like:
+        aidevkit v0.3.0
+        - devkit
+    """
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("-"):
+            continue
+        m = _UV_TOOL_ENTRY_RE.match(stripped)
+        if m and m.group(1) == package:
+            return m.group(2)
+    return None
+
+
+def _parse_pip_show_version(text: str) -> Optional[str]:
+    for line in text.splitlines():
+        if line.lower().startswith("version:"):
+            return line.split(":", 1)[1].strip()
+    return None
+
+
+def _parse_pip_show_location(text: str) -> Optional[str]:
+    for line in text.splitlines():
+        if line.lower().startswith("location:"):
+            return line.split(":", 1)[1].strip()
+    return None
+
+
+def detect_install_info(package: str = "aidevkit") -> InstallInfo:
+    """Detect how `package` is installed. Order: uv tool → pip → source → unknown."""
+    uv_list = util.run(["uv", "tool", "list"])
+    if uv_list.code == 0:
+        version = _parse_uv_tool_list(uv_list.stdout, package)
+        if version is not None:
+            return InstallInfo(
+                method="uv-tool",
+                installed_version=version,
+                tool_venv_path=None,
+                manageable=True,
+            )
+
+    pip_show = util.run(["pip", "show", package])
+    if pip_show.code == 0 and pip_show.stdout.strip():
+        version = _parse_pip_show_version(pip_show.stdout)
+        location = _parse_pip_show_location(pip_show.stdout)
+        method: Method = "pip"
+        if location and ("/site-packages" not in location):
+            # `pip show` reports a location that does NOT look like a standard
+            # venv/site-packages — treat as a source/editable checkout.
+            method = "source"
+        return InstallInfo(
+            method=method,
+            installed_version=version,
+            tool_venv_path=None,
+            manageable=False,
+        )
+
+    return InstallInfo(
+        method="unknown",
+        installed_version=None,
+        tool_venv_path=None,
+        manageable=False,
+    )

--- a/src/aidevkit/_prs.py
+++ b/src/aidevkit/_prs.py
@@ -1,0 +1,107 @@
+"""Shared PR-merge helpers.
+
+`archive` uses ``check_prs_merged`` as a precondition check; `status` uses
+``prs_for_branch`` to render per-repo PR lists and derive the `archivable`
+flag. Extracting these keeps the PR-state signal consistent across the two
+commands (FR-STAT-004b).
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from .util import gh
+
+
+@dataclass
+class PR:
+    number: int
+    state: Literal["open", "merged", "closed"]
+    url: str
+
+
+def check_prs_merged(
+    repos: list[tuple[str, Path]],
+    branch: str,
+) -> list[str]:
+    """Return list of blocker descriptions (empty list == all merged).
+
+    A "blocker" is any PR on `branch` in any repo with state != 'MERGED'.
+    """
+    blockers: list[str] = []
+    for owner_repo, _path in repos:
+        res = gh(
+            "pr", "list",
+            "--repo", owner_repo,
+            "--head", branch,
+            "--state", "all",
+            "--json", "number,state,url",
+        )
+        if res.code != 0:
+            blockers.append(
+                f"{owner_repo} — failed to query PRs: "
+                f"{res.stderr.strip() or res.stdout.strip()}"
+            )
+            continue
+        try:
+            prs = json.loads(res.stdout or "[]")
+        except json.JSONDecodeError:
+            blockers.append(f"{owner_repo} — unparseable PR list")
+            continue
+        for pr in prs:
+            if pr.get("state") != "MERGED":
+                blockers.append(
+                    f"{owner_repo}#{pr.get('number')} ({pr.get('state')}) — "
+                    f"{pr.get('url')}"
+                )
+    return blockers
+
+
+def prs_for_branch(
+    repos: list[tuple[str, Path]],
+    branch: str,
+) -> dict[str, list[PR]]:
+    """Return per-repo PR lists keyed by owner/repo slug.
+
+    On query failure or parse failure for a given repo, the value is an empty
+    list (caller decides how to surface the degraded signal — `status`
+    degrades the whole workspace via `issue.state = "unknown"` when
+    GitHub-reachability is suspect).
+    """
+    result: dict[str, list[PR]] = {}
+    for owner_repo, _path in repos:
+        res = gh(
+            "pr", "list",
+            "--repo", owner_repo,
+            "--head", branch,
+            "--state", "all",
+            "--json", "number,state,url",
+        )
+        if res.code != 0:
+            result[owner_repo] = []
+            continue
+        try:
+            raw = json.loads(res.stdout or "[]")
+        except json.JSONDecodeError:
+            result[owner_repo] = []
+            continue
+        prs: list[PR] = []
+        for pr in raw:
+            gh_state = (pr.get("state") or "").upper()
+            if gh_state == "MERGED":
+                state: Literal["open", "merged", "closed"] = "merged"
+            elif gh_state == "OPEN":
+                state = "open"
+            else:
+                state = "closed"
+            prs.append(
+                PR(
+                    number=int(pr.get("number") or 0),
+                    state=state,
+                    url=str(pr.get("url") or ""),
+                )
+            )
+        result[owner_repo] = prs
+    return result

--- a/src/aidevkit/add_repo.py
+++ b/src/aidevkit/add_repo.py
@@ -1,0 +1,9 @@
+"""`devkit add-repo` — stub; real implementation lands in US2 phase."""
+from __future__ import annotations
+
+from .util import log
+
+
+def cmd_add_repo(repo_name: str) -> int:
+    log(f"add-repo: not yet implemented ({repo_name})")
+    return 0

--- a/src/aidevkit/add_repo.py
+++ b/src/aidevkit/add_repo.py
@@ -1,9 +1,172 @@
-"""`devkit add-repo` — stub; real implementation lands in US2 phase."""
+"""`devkit add-repo` — add a sibling repo's worktree to the current per-issue workspace.
+
+Invoked from anywhere inside `$APP_EMPIRE_WORKTREES_HOME/<Repo>-issue-<N>/`.
+Walks the CWD's ancestors to find the per-issue workspace, resolves the named
+sibling repo under `$APP_EMPIRE_PROJECTS/<name>`, and adds a `git worktree` on
+the issue's branch (creating the branch if absent). Idempotent — if the
+target subdir already contains a valid worktree, the command logs a skip and
+exits 0.
+"""
 from __future__ import annotations
 
-from .util import log
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .util import (
+    E_NOT_IN_PER_ISSUE_WORKSPACE,
+    E_REPO_NOT_FOUND,
+    E_WORKSPACE_MISSING,
+    die,
+    git,
+    info,
+    log,
+)
+
+_WS_NAME_RE = re.compile(r"^(?P<repo>[A-Za-z0-9_.-]+)-issue-(?P<n>\d+)$")
+
+
+@dataclass
+class PerIssueContext:
+    workspace_dir: Path
+    home_repo_name: str
+    issue_number: int
+    branch: str
+
+
+def _detect_per_issue_context(cwd: Path, home: Path) -> PerIssueContext:
+    """Walk ancestors; first ancestor directly under `home` that matches the
+    `<Repo>-issue-<N>` pattern wins.
+    """
+    cwd_resolved = cwd.resolve()
+    home_resolved = home.resolve()
+    current: Optional[Path] = cwd_resolved
+    while current is not None:
+        parent = current.parent
+        if parent == home_resolved:
+            if current.name.startswith("_"):
+                break
+            m = _WS_NAME_RE.match(current.name)
+            if m:
+                return PerIssueContext(
+                    workspace_dir=current,
+                    home_repo_name=m.group("repo"),
+                    issue_number=int(m.group("n")),
+                    branch=f"issue-{m.group('repo')}-{m.group('n')}",
+                )
+            break
+        if parent == current:
+            break
+        current = parent
+    die(
+        f"not inside a per-issue workspace (cwd={cwd_resolved}). "
+        f"cd into $APP_EMPIRE_WORKTREES_HOME/<Repo>-issue-<N>/ first.",
+        code=E_NOT_IN_PER_ISSUE_WORKSPACE,
+    )
+    # unreachable
+    raise SystemExit(E_NOT_IN_PER_ISSUE_WORKSPACE)
+
+
+def _resolve_source_repo(name: str, projects: Path) -> Path:
+    source = projects / name
+    if not source.is_dir():
+        die(
+            f"source repo not found at {source}. "
+            f"Clone it first: git clone <url> {source}",
+            code=E_REPO_NOT_FOUND,
+        )
+    return source
+
+
+def _target_points_into(source_repo: Path, target_path: Path) -> bool:
+    """True if `target_path/.git` is a worktree file pointing inside `source_repo`."""
+    dotgit = target_path / ".git"
+    if not dotgit.is_file():
+        return False
+    try:
+        content = dotgit.read_text(errors="replace").strip()
+    except OSError:
+        return False
+    m = re.match(r"gitdir:\s*(.+)$", content)
+    if not m:
+        return False
+    try:
+        worktree_gitdir = Path(m.group(1)).resolve()
+        source_resolved = source_repo.resolve()
+    except Exception:
+        return False
+    try:
+        worktree_gitdir.relative_to(source_resolved)
+        return True
+    except ValueError:
+        return False
+
+
+def _branch_exists(source_repo: Path, branch: str) -> bool:
+    res = git("show-ref", "--verify", f"refs/heads/{branch}", cwd=source_repo)
+    return res.code == 0
+
+
+def _ensure_worktree(source_repo: Path, target_path: Path, branch: str) -> bool:
+    """Return True when a new worktree was created, False on idempotent skip."""
+    if target_path.exists():
+        if _target_points_into(source_repo, target_path):
+            info(f"worktree already present at {target_path} — skipping")
+            return False
+        die(
+            f"target path {target_path} exists but is not a git worktree of "
+            f"{source_repo}. Resolve the conflict before retrying.",
+            code=E_REPO_NOT_FOUND,
+        )
+
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if _branch_exists(source_repo, branch):
+        res = git("worktree", "add", str(target_path), branch, cwd=source_repo)
+    else:
+        res = git(
+            "worktree", "add", "-b", branch, str(target_path),
+            cwd=source_repo,
+        )
+    if res.code != 0:
+        die(
+            f"git worktree add failed: "
+            f"{res.stderr.strip() or res.stdout.strip() or 'unknown error'}",
+        )
+    return True
 
 
 def cmd_add_repo(repo_name: str) -> int:
-    log(f"add-repo: not yet implemented ({repo_name})")
+    home_env = os.environ.get("APP_EMPIRE_WORKTREES_HOME")
+    projects_env = os.environ.get("APP_EMPIRE_PROJECTS")
+    if not home_env or not projects_env:
+        die(
+            "$APP_EMPIRE_WORKTREES_HOME and $APP_EMPIRE_PROJECTS must both "
+            "be set (run 'devkit doctor')",
+            code=E_WORKSPACE_MISSING,
+        )
+    home = Path(home_env)
+    projects = Path(projects_env)
+    if not home.is_dir():
+        die(f"$APP_EMPIRE_WORKTREES_HOME is not a directory: {home_env}",
+            code=E_WORKSPACE_MISSING)
+    if not projects.is_dir():
+        die(f"$APP_EMPIRE_PROJECTS is not a directory: {projects_env}",
+            code=E_WORKSPACE_MISSING)
+
+    ctx = _detect_per_issue_context(Path.cwd(), home)
+    source = _resolve_source_repo(repo_name, projects)
+    target = ctx.workspace_dir / repo_name
+
+    info(f"[devkit] Adding worktree: {repo_name} → {target}")
+    info(f"  source:  {source}")
+    info(f"  branch:  {ctx.branch}")
+
+    created = _ensure_worktree(source, target, ctx.branch)
+    if created:
+        info(f"worktree created at {target} on {ctx.branch}")
+    else:
+        log("no changes (idempotent skip)")
     return 0

--- a/src/aidevkit/archive.py
+++ b/src/aidevkit/archive.py
@@ -10,6 +10,7 @@ See `specs/4-archive-subcommand/spec.md` for the full specification and
 """
 from __future__ import annotations
 
+import datetime
 import json
 import os
 import re
@@ -18,6 +19,7 @@ import tempfile
 from pathlib import Path
 from typing import Optional
 
+from ._prs import check_prs_merged as _check_prs_merged
 from .util import (
     E_ARCHIVE_COLLISION,
     E_DEP_MISSING,
@@ -186,44 +188,6 @@ def _parse_owner_repo_from_url(url: str) -> Optional[str]:
     return f"{m.group(1)}/{m.group(2)}"
 
 
-def _check_prs_merged(
-    repos: list[tuple[str, Path]],
-    branch: str,
-) -> list[str]:
-    """Return list of blocker descriptions (empty list == all merged).
-
-    A "blocker" is any PR on `branch` in any repo with state != 'MERGED'.
-    """
-    blockers: list[str] = []
-    for owner_repo, _path in repos:
-        res = gh(
-            "pr", "list",
-            "--repo", owner_repo,
-            "--head", branch,
-            "--state", "all",
-            "--json", "number,state,url",
-        )
-        if res.code != 0:
-            # Treat query failure as a blocker — we can't verify safety.
-            blockers.append(
-                f"{owner_repo} — failed to query PRs: "
-                f"{res.stderr.strip() or res.stdout.strip()}"
-            )
-            continue
-        try:
-            prs = json.loads(res.stdout or "[]")
-        except json.JSONDecodeError:
-            blockers.append(f"{owner_repo} — unparseable PR list")
-            continue
-        for pr in prs:
-            if pr.get("state") != "MERGED":
-                blockers.append(
-                    f"{owner_repo}#{pr.get('number')} ({pr.get('state')}) — "
-                    f"{pr.get('url')}"
-                )
-    return blockers
-
-
 def _find_spec_files(workspace: Path) -> list[Path]:
     """Return sorted list of `<workspace>/specs/*/spec.md` paths (one level deep)."""
     specs_dir = workspace / "specs"
@@ -345,11 +309,19 @@ def _close_issue_if_open(owner_repo: str, num: int) -> str:
 
 
 def _move_to_archived(workspace: Path) -> Path:
-    """Move `workspace` under `<home>/_archived/`. Returns the destination path."""
+    """Move `workspace` under `<home>/_archived/` and drop a `.devkit-archived` marker.
+
+    The marker is a single-line ISO 8601 UTC timestamp captured at archive
+    time. `devkit purge` reads it to age-gate deletion — missing or
+    unparseable markers cause purge to skip the directory (FR-PURGE-004a).
+    Marker-write failure propagates so archive exits non-zero (FR-ARCH-002).
+    """
     archived_root = workspace.parent / "_archived"
     archived_root.mkdir(parents=True, exist_ok=True)
     dest = archived_root / workspace.name
     shutil.move(str(workspace), str(dest))
+    timestamp = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    (dest / ".devkit-archived").write_text(f"{timestamp}\n")
     return dest
 
 

--- a/src/aidevkit/check_update.py
+++ b/src/aidevkit/check_update.py
@@ -1,9 +1,118 @@
-"""`devkit check-update` — stub; real implementation lands in US4 phase."""
+"""`devkit check-update` — non-destructive "is there an update?" oracle.
+
+Uses `uv tool upgrade --dry-run aidevkit` as the source of truth: whatever
+`devkit update` would actually install is by definition the "latest" we
+report. No hardcoded index URL; no parsing of `~/.local/share/uv/tools/`
+metadata. If the dry-run can't resolve an index (e.g., source-checkout
+install), exit 27 per FR-SELF-011.
+"""
 from __future__ import annotations
 
-from .util import log
+import json
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+from . import util
+from ._install import detect_install_info
+from .util import (
+    E_CHECK_UPDATE_INDEX_UNAVAILABLE,
+    die,
+    info,
+    out,
+)
+
+_WOULD_INSTALL_RE = re.compile(
+    r"(?:Would install|install|Updated)\s+aidevkit\s*(?:==|=|@)?\s*v?([0-9][^\s]*)",
+    re.IGNORECASE,
+)
+_UP_TO_DATE_RE = re.compile(r"up\s*to\s*date|no\s+updates?\s+available", re.IGNORECASE)
+
+
+@dataclass
+class UpdateCheckResult:
+    installed: str
+    latest: Optional[str]
+    update_available: bool
+    unresolvable_reason: Optional[str]
+
+
+def _parse_dry_run_output(text: str) -> tuple[Optional[str], bool]:
+    """Return (latest_version, is_up_to_date). (None, False) means unresolvable."""
+    if _UP_TO_DATE_RE.search(text):
+        return None, True
+    m = _WOULD_INSTALL_RE.search(text)
+    if m:
+        return m.group(1), False
+    return None, False
 
 
 def cmd_check_update(json_output: bool) -> int:
-    log("check-update: not yet implemented")
+    install = detect_install_info()
+    installed = install.installed_version or "unknown"
+
+    dry = util.run(["uv", "tool", "upgrade", "--dry-run", "aidevkit"])
+    if dry.code != 0 and not dry.stdout and not dry.stderr:
+        die(
+            "uv tool upgrade --dry-run aidevkit returned no output — "
+            "cannot determine latest version. Is `uv` installed and is "
+            "aidevkit reachable via your configured index?",
+            code=E_CHECK_UPDATE_INDEX_UNAVAILABLE,
+        )
+
+    combined = (dry.stdout or "") + "\n" + (dry.stderr or "")
+    latest, up_to_date = _parse_dry_run_output(combined)
+
+    if up_to_date:
+        result = UpdateCheckResult(
+            installed=installed,
+            latest=installed if installed != "unknown" else None,
+            update_available=False,
+            unresolvable_reason=None,
+        )
+    elif latest is not None:
+        update_available = installed != "unknown" and latest != installed
+        result = UpdateCheckResult(
+            installed=installed,
+            latest=latest,
+            update_available=update_available,
+            unresolvable_reason=None,
+        )
+    else:
+        reason = (
+            "could not parse `uv tool upgrade --dry-run aidevkit` output; "
+            "the configured index may be unavailable or aidevkit may be "
+            "installed from a local source checkout."
+        )
+        if json_output:
+            payload = {
+                "installed": installed,
+                "latest": None,
+                "update_available": False,
+                "unresolvable_reason": reason,
+            }
+            out.print(json.dumps(payload, indent=2))
+        die(reason, code=E_CHECK_UPDATE_INDEX_UNAVAILABLE)
+        return E_CHECK_UPDATE_INDEX_UNAVAILABLE  # unreachable
+
+    if json_output:
+        out.print(
+            json.dumps(
+                {
+                    "installed": result.installed,
+                    "latest": result.latest,
+                    "update_available": result.update_available,
+                    "unresolvable_reason": result.unresolvable_reason,
+                },
+                indent=2,
+            )
+        )
+    else:
+        if result.update_available:
+            info(
+                f"update available: {result.installed} → {result.latest}. "
+                f"Run `devkit update`."
+            )
+        else:
+            info(f"aidevkit is up to date ({result.installed}).")
     return 0

--- a/src/aidevkit/check_update.py
+++ b/src/aidevkit/check_update.py
@@ -1,0 +1,9 @@
+"""`devkit check-update` — stub; real implementation lands in US4 phase."""
+from __future__ import annotations
+
+from .util import log
+
+
+def cmd_check_update(json_output: bool) -> int:
+    log("check-update: not yet implemented")
+    return 0

--- a/src/aidevkit/cli.py
+++ b/src/aidevkit/cli.py
@@ -3,12 +3,18 @@ from __future__ import annotations
 import typer
 
 from . import __version__
+from . import add_repo as _add_repo
 from . import archive as _archive
 from . import bootstrap as _bootstrap
+from . import check_update as _check_update
 from . import doctor as _doctor
 from . import preflight as _preflight
+from . import purge as _purge
 from . import setup as _setup
+from . import status as _status
 from . import sync as _sync
+from . import uninstall as _uninstall
+from . import update as _update
 from .util import info
 
 app = typer.Typer(
@@ -110,6 +116,61 @@ def archive(
 )
 def preflight() -> None:
     code = _preflight.cmd_preflight()
+    raise typer.Exit(code=code)
+
+
+@app.command(help="Summarize every active per-issue workspace: issue state, branches, PRs.")
+def status(
+    json: bool = typer.Option(
+        False, "--json", help="Emit machine-readable JSON per the v1 schema."
+    ),
+) -> None:
+    code = _status.cmd_status(json_output=json)
+    raise typer.Exit(code=code)
+
+
+@app.command("add-repo", help="Add a sibling repo's worktree to the current per-issue workspace.")
+def add_repo(
+    repo_name: str = typer.Argument(
+        ...,
+        metavar="REPO_NAME",
+        help="Sibling repo directory name under $APP_EMPIRE_PROJECTS.",
+    ),
+) -> None:
+    code = _add_repo.cmd_add_repo(repo_name=repo_name)
+    raise typer.Exit(code=code)
+
+
+@app.command(help="Remove archived workspaces older than the retention threshold.")
+def purge(
+    days: int = typer.Option(30, "--days", help="Retention threshold in days (default: 30)."),
+    yes: bool = typer.Option(
+        False, "--yes", help="Actually delete. Without this flag the command is a dry-run."
+    ),
+) -> None:
+    code = _purge.cmd_purge(days=days, yes=yes)
+    raise typer.Exit(code=code)
+
+
+@app.command(help="Remove DevKit: uninstall aidevkit and unlink slash commands.")
+def uninstall() -> None:
+    code = _uninstall.cmd_uninstall()
+    raise typer.Exit(code=code)
+
+
+@app.command(help="Upgrade DevKit to the latest release, then run doctor.")
+def update() -> None:
+    code = _update.cmd_update()
+    raise typer.Exit(code=code)
+
+
+@app.command("check-update", help="Check whether a newer aidevkit release is available.")
+def check_update(
+    json: bool = typer.Option(
+        False, "--json", help="Emit machine-readable JSON."
+    ),
+) -> None:
+    code = _check_update.cmd_check_update(json_output=json)
     raise typer.Exit(code=code)
 
 

--- a/src/aidevkit/commands/devkit.add-repo.md
+++ b/src/aidevkit/commands/devkit.add-repo.md
@@ -1,0 +1,45 @@
+---
+description: Add a sibling repo's worktree to the current per-issue workspace
+---
+
+# /devkit.add-repo
+
+From anywhere inside `$APP_EMPIRE_WORKTREES_HOME/<Repo>-issue-<N>/`, add a
+sibling repo's git worktree on the current issue branch. The command infers
+the workspace, branch, and source path from CWD — the user only supplies the
+sibling repo's directory name.
+
+## Usage
+
+The user gives you a sibling repo name (e.g., `AuthService`):
+
+    /devkit.add-repo AuthService
+
+## What to do
+
+1. Run the command:
+
+       devkit add-repo <name>
+
+2. On success, the worktree lives at `<workspace>/<name>/` on the workspace's
+   `issue-<HomeRepo>-<N>` branch. Re-running is a safe no-op.
+
+3. Exit-code handling:
+   - `13` (source repo not found) — the sibling isn't cloned under
+     `$APP_EMPIRE_PROJECTS`. Tell the user to clone it first. Do NOT clone
+     on their behalf.
+   - `24` (not in per-issue workspace) — the user is running this from
+     outside a `<Repo>-issue-<N>` tree. Tell them to `cd` into the workspace.
+   - `16` (env missing) — `$APP_EMPIRE_WORKTREES_HOME` or
+     `$APP_EMPIRE_PROJECTS` is unset or not a directory. Run
+     `devkit doctor`.
+   - Any other non-zero — surface the message; don't retry.
+
+## Notes
+
+- Idempotent: if `<workspace>/<name>/` already has a valid worktree pointing
+  into the source repo, the command logs a skip and exits 0.
+- If the `issue-<HomeRepo>-<N>` branch does not yet exist in the source repo,
+  it is created at HEAD (default: `git worktree add -b`).
+- Never mutates the source repo beyond the worktree registration; never
+  runs destructive git commands.

--- a/src/aidevkit/commands/devkit.purge.md
+++ b/src/aidevkit/commands/devkit.purge.md
@@ -1,0 +1,57 @@
+---
+description: Remove archived workspaces older than the retention threshold
+---
+
+# /devkit.purge
+
+Delete directories under `$APP_EMPIRE_WORKTREES_HOME/_archived/` whose
+`.devkit-archived` marker timestamp is older than the retention threshold
+(default 30 days). **Dry-run by default** — the user must pass `--yes` to
+actually delete.
+
+Directories without a valid marker are never deleted — only `devkit archive`
+writes markers, so a missing/unparseable marker is evidence that the dir
+wasn't created by `devkit archive` and the user owns it.
+
+## Usage
+
+    /devkit.purge
+    /devkit.purge --days 7
+    /devkit.purge --yes
+    /devkit.purge --days 60 --yes
+
+## What to do
+
+1. Run the command:
+
+       devkit purge [--days N] [--yes]
+
+2. The command prints:
+   - `would purge <dir>` — dry-run candidate.
+   - `purged <dir>` — actually deleted (only with `--yes`).
+   - `keep <dir>: age N days < threshold T` — within the retention window.
+   - `SKIP <dir>: <reason>` — marker missing/empty/unparseable/future.
+     These are never deleted, regardless of flags.
+
+3. If a deletion fails (permission, race), the command reports the failed
+   path and exits non-zero. Other eligible deletions in the same run still
+   happen — the command does not roll back successful deletions.
+
+4. Active (non-archived) workspaces sit at the root of
+   `$APP_EMPIRE_WORKTREES_HOME`, not under `_archived/` — purge never
+   enumerates them. Tell the user this explicitly if they worry about data loss.
+
+## Flags
+
+- `--days N` — override the retention threshold (default 30).
+- `--yes` — perform deletions. Without this, the command is strictly a
+  dry-run report.
+
+## Notes
+
+- `purge` is never automatic. No cron, no archive-time deletion.
+- The marker file is one line of ISO 8601 UTC (e.g.,
+  `2026-04-22T14:37:22Z`). Date-only strings and timezone-offset variants
+  are accepted on read. See `specs/20-lifecycle-and-self-mgmt/contracts/marker-file.md`.
+- Exit code `16` means `$APP_EMPIRE_WORKTREES_HOME` is unset or not a
+  directory (run `devkit doctor`).

--- a/src/aidevkit/commands/devkit.status.md
+++ b/src/aidevkit/commands/devkit.status.md
@@ -1,0 +1,76 @@
+---
+description: Summarize every active per-issue workspace at a glance
+---
+
+# /devkit.status
+
+Print one entry per active workspace under `$APP_EMPIRE_WORKTREES_HOME`:
+issue state, per-repo branch state (ahead/behind/dirty), PRs associated with
+each branch, and a workspace-level `archivable` flag (issue closed AND every
+repo has at least one merged PR — shares signal with `devkit archive`).
+
+`_archived/` is excluded. Missing or externally-deleted worktrees are reported
+without crashing.
+
+## Usage
+
+    /devkit.status
+
+Takes no arguments.
+
+## What to do
+
+1. Run with JSON so the output is parseable:
+
+       devkit status --json
+
+2. Parse stdout as a single JSON document. Schema:
+   `importlib.resources.files("aidevkit.schemas") / "status.schema.json"`.
+   Top-level fields: `version` (currently `1`), `workspaces[]`. Each workspace
+   has `dir_name`, `issue {owner_repo, number, title, state}`, `branch`,
+   `archivable`, and `repos[]`. Each repo has `name`, `worktree_present`,
+   `branch_state {ahead, behind, dirty, missing}`, and `prs[]`.
+
+3. For each workspace summarize for the user:
+   - Issue line: `<dir_name>  <owner>/<repo>#<N>  (<state>)` + `[archivable]`
+     when applicable.
+   - Per-repo line: `<name>  ahead N  behind M  [dirty]  [branch-missing]`
+     (or `worktree: MISSING` if externally deleted).
+   - PR lines: `PR #<n> <state> <url>` — one per PR.
+
+4. If `issue.state == "unknown"` anywhere, GitHub was unreachable for that
+   workspace — surface that, don't guess.
+
+## Example JSON
+
+```json
+{
+  "version": 1,
+  "workspaces": [
+    {
+      "dir_name": "DevKit-issue-20",
+      "issue": {"owner_repo": "App-Empire-LLC/DevKit", "number": 20,
+                "title": "Lifecycle commands", "state": "open"},
+      "branch": "issue-DevKit-20",
+      "archivable": false,
+      "repos": [
+        {
+          "name": "DevKit",
+          "worktree_present": true,
+          "branch_state": {"ahead": 2, "behind": 0, "dirty": false, "missing": false},
+          "prs": []
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Notes
+
+- Read-only. Never mutates filesystem or git state.
+- GH unreachability (auth, rate limit, offline) degrades the issue/PR fields
+  to `"unknown"` / empty; local git state is still reported. The command
+  always exits 0 for reachability issues — not a failure.
+- Exit code `16` means `$APP_EMPIRE_WORKTREES_HOME` is unset or not a
+  directory (run `devkit doctor`).

--- a/src/aidevkit/purge.py
+++ b/src/aidevkit/purge.py
@@ -1,0 +1,9 @@
+"""`devkit purge` — stub; real implementation lands in US3 phase."""
+from __future__ import annotations
+
+from .util import log
+
+
+def cmd_purge(days: int, yes: bool) -> int:
+    log("purge: not yet implemented")
+    return 0

--- a/src/aidevkit/purge.py
+++ b/src/aidevkit/purge.py
@@ -1,9 +1,182 @@
-"""`devkit purge` — stub; real implementation lands in US3 phase."""
+"""`devkit purge` — delete old archived workspaces after a retention window.
+
+Scans `$APP_EMPIRE_WORKTREES_HOME/_archived/`, reads the `.devkit-archived`
+marker inside each directory, and deletes dirs older than the threshold
+(default 30 days). Dry-run by default; requires `--yes` to mutate the
+filesystem. Dirs without a valid marker are skipped with a warning — never
+deleted (FR-PURGE-004a).
+"""
 from __future__ import annotations
 
-from .util import log
+import datetime
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .util import (
+    E_WORKSPACE_MISSING,
+    die,
+    info,
+    log,
+)
+
+_MARKER_NAME = ".devkit-archived"
+_FUTURE_SKEW_SECONDS = 60
+
+
+@dataclass
+class ArchivedEntry:
+    path: Path
+    archived_at: Optional[datetime.datetime]
+    marker_error: Optional[str]
+    age_days: Optional[int]
+
+
+def _parse_marker(marker: Path, now: datetime.datetime) -> ArchivedEntry:
+    if not marker.is_file():
+        return ArchivedEntry(
+            path=marker.parent,
+            archived_at=None,
+            marker_error="marker file missing",
+            age_days=None,
+        )
+    try:
+        text = marker.read_text().strip()
+    except OSError as exc:
+        return ArchivedEntry(
+            path=marker.parent,
+            archived_at=None,
+            marker_error=f"could not read marker: {exc}",
+            age_days=None,
+        )
+    if not text:
+        return ArchivedEntry(
+            path=marker.parent,
+            archived_at=None,
+            marker_error="marker file empty",
+            age_days=None,
+        )
+    first_line = text.splitlines()[0].strip()
+    raw = first_line
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        parsed = datetime.datetime.fromisoformat(raw)
+    except ValueError as exc:
+        return ArchivedEntry(
+            path=marker.parent,
+            archived_at=None,
+            marker_error=f"unparseable timestamp '{first_line}': {exc}",
+            age_days=None,
+        )
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=datetime.UTC)
+    if parsed > now + datetime.timedelta(seconds=_FUTURE_SKEW_SECONDS):
+        return ArchivedEntry(
+            path=marker.parent,
+            archived_at=parsed,
+            marker_error=f"marker timestamp is in the future: {first_line}",
+            age_days=None,
+        )
+    age = now - parsed
+    return ArchivedEntry(
+        path=marker.parent,
+        archived_at=parsed,
+        marker_error=None,
+        age_days=age.days,
+    )
+
+
+def _enumerate_archived(home: Path) -> list[ArchivedEntry]:
+    archived_root = home / "_archived"
+    if not archived_root.is_dir():
+        return []
+    now = datetime.datetime.now(datetime.UTC)
+    entries: list[ArchivedEntry] = []
+    for child in sorted(archived_root.iterdir()):
+        if not child.is_dir():
+            continue
+        entries.append(_parse_marker(child / _MARKER_NAME, now))
+    return entries
+
+
+def _eligible(entry: ArchivedEntry, threshold_days: int) -> bool:
+    if entry.marker_error is not None:
+        return False
+    if entry.age_days is None:
+        return False
+    return entry.age_days >= threshold_days
 
 
 def cmd_purge(days: int, yes: bool) -> int:
-    log("purge: not yet implemented")
+    home_env = os.environ.get("APP_EMPIRE_WORKTREES_HOME")
+    if not home_env:
+        die("$APP_EMPIRE_WORKTREES_HOME not set (run 'devkit doctor')",
+            code=E_WORKSPACE_MISSING)
+    home = Path(home_env)
+    if not home.is_dir():
+        die(f"$APP_EMPIRE_WORKTREES_HOME is not a directory: {home_env}",
+            code=E_WORKSPACE_MISSING)
+
+    archived_root = home / "_archived"
+    if not archived_root.is_dir():
+        info("nothing to purge — no _archived/ directory")
+        return 0
+
+    entries = _enumerate_archived(home)
+    if not entries:
+        info("nothing to purge — _archived/ is empty")
+        return 0
+
+    mode = "DELETE" if yes else "DRY RUN"
+    info(f"purge [{mode}] — threshold: {days} days; scanning {archived_root}")
+
+    purged: list[Path] = []
+    skipped_marker: list[tuple[Path, str]] = []
+    too_new: list[tuple[Path, int]] = []
+    deletion_failures: list[tuple[Path, str]] = []
+
+    for entry in entries:
+        if entry.marker_error is not None:
+            skipped_marker.append((entry.path, entry.marker_error))
+            log(
+                f"SKIP {entry.path.name}: {entry.marker_error} "
+                f"(refusing to delete without a valid marker)"
+            )
+            continue
+        if not _eligible(entry, days):
+            too_new.append((entry.path, entry.age_days or 0))
+            info(
+                f"keep {entry.path.name}: age {entry.age_days} days "
+                f"< threshold {days}"
+            )
+            continue
+        if not yes:
+            info(f"would purge {entry.path.name} (age {entry.age_days} days)")
+            continue
+        try:
+            shutil.rmtree(entry.path)
+            purged.append(entry.path)
+            info(f"purged {entry.path.name} (age {entry.age_days} days)")
+        except OSError as exc:
+            deletion_failures.append((entry.path, str(exc)))
+            log(f"FAILED to delete {entry.path}: {exc}")
+
+    info("")
+    if yes:
+        info(f"Purged {len(purged)} director{'y' if len(purged) == 1 else 'ies'}.")
+    else:
+        would = [e for e in entries if _eligible(e, days)]
+        info(
+            f"Dry run: {len(would)} director{'y' if len(would) == 1 else 'ies'} "
+            f"would be purged. Re-run with --yes to delete."
+        )
+    if skipped_marker:
+        info(f"Skipped (missing/invalid marker): {len(skipped_marker)}")
+    if too_new:
+        info(f"Within retention window: {len(too_new)}")
+    if deletion_failures:
+        return 1
     return 0

--- a/src/aidevkit/schemas/status.schema.json
+++ b/src/aidevkit/schemas/status.schema.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/App-Empire-LLC/DevKit/schemas/status.schema.json",
+  "title": "devkit status --json output",
+  "description": "Stable v1 contract for machine-readable output of `devkit status --json`. Additive changes only across patch/minor; breaking changes bump the top-level `version` integer.",
+  "type": "object",
+  "required": ["version", "workspaces"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version. Bumped only on breaking contract changes."
+    },
+    "workspaces": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/workspace" }
+    }
+  },
+  "$defs": {
+    "workspace": {
+      "type": "object",
+      "required": ["dir_name", "issue", "branch", "archivable", "repos"],
+      "additionalProperties": false,
+      "properties": {
+        "dir_name": {
+          "type": "string",
+          "description": "Workspace directory name under $APP_EMPIRE_WORKTREES_HOME (e.g., 'DevKit-issue-20').",
+          "pattern": "^[A-Za-z0-9_.-]+-issue-\\d+$"
+        },
+        "issue": { "$ref": "#/$defs/issue" },
+        "branch": {
+          "type": "string",
+          "description": "The issue branch name shared across all worktrees in this workspace (e.g., 'issue-DevKit-20')."
+        },
+        "archivable": {
+          "type": "boolean",
+          "description": "True iff issue.state == 'closed' AND every repo has at least one merged PR on the branch."
+        },
+        "repos": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/repo" }
+        }
+      }
+    },
+    "issue": {
+      "type": "object",
+      "required": ["owner_repo", "number", "title", "state"],
+      "additionalProperties": false,
+      "properties": {
+        "owner_repo": {
+          "type": "string",
+          "description": "GitHub 'owner/repo' slug."
+        },
+        "number": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "title": {
+          "type": "string",
+          "description": "Empty string when state is 'unknown' and title could not be fetched."
+        },
+        "state": {
+          "type": "string",
+          "enum": ["open", "closed", "unknown"],
+          "description": "'unknown' when GitHub was unreachable or auth failed."
+        }
+      }
+    },
+    "repo": {
+      "type": "object",
+      "required": ["name", "worktree_present", "branch_state", "prs"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "worktree_present": {
+          "type": "boolean",
+          "description": "False when the subdir is missing or its .git file is invalid (FR-STAT-006)."
+        },
+        "branch_state": {
+          "oneOf": [
+            { "type": "null" },
+            { "$ref": "#/$defs/branch_state" }
+          ],
+          "description": "null when worktree_present is false."
+        },
+        "prs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/pr" },
+          "description": "PRs associated with this repo's branch. Empty array = no PRs. May be empty when GitHub is unreachable; consumers should not infer 'no PRs' from an empty array without also checking that issue.state is not 'unknown'."
+        }
+      }
+    },
+    "branch_state": {
+      "type": "object",
+      "required": ["ahead", "behind", "dirty", "missing"],
+      "additionalProperties": false,
+      "properties": {
+        "ahead": { "type": "integer", "minimum": 0 },
+        "behind": { "type": "integer", "minimum": 0 },
+        "dirty": { "type": "boolean" },
+        "missing": {
+          "type": "boolean",
+          "description": "True when the branch or its upstream has been deleted out from under the worktree."
+        }
+      }
+    },
+    "pr": {
+      "type": "object",
+      "required": ["number", "state", "url"],
+      "additionalProperties": false,
+      "properties": {
+        "number": { "type": "integer", "minimum": 1 },
+        "state": {
+          "type": "string",
+          "enum": ["open", "merged", "closed"],
+          "description": "'closed' means closed-without-merge."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    }
+  }
+}

--- a/src/aidevkit/status.py
+++ b/src/aidevkit/status.py
@@ -1,0 +1,9 @@
+"""`devkit status` — stub; real implementation lands in US1 phase."""
+from __future__ import annotations
+
+from .util import log
+
+
+def cmd_status(json_output: bool) -> int:
+    log("status: not yet implemented")
+    return 0

--- a/src/aidevkit/status.py
+++ b/src/aidevkit/status.py
@@ -1,9 +1,372 @@
-"""`devkit status` — stub; real implementation lands in US1 phase."""
+"""`devkit status` — summarize every active per-issue workspace.
+
+Scans `$APP_EMPIRE_WORKTREES_HOME`, enumerates `<Repo>-issue-<N>` dirs
+(excluding `_archived/`), and for each workspace collects issue state,
+per-repo branch state, and per-branch PR lists. A workspace-level
+`archivable` flag is derived from the PR-merged signal (shared with
+`devkit archive` via `_prs.py`).
+
+Output modes: human-readable text (default) and JSON (`--json`, conforms to
+`aidevkit/schemas/status.schema.json`).
+"""
 from __future__ import annotations
 
-from .util import log
+import concurrent.futures
+import dataclasses
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal, Optional
+
+from ._prs import PR, prs_for_branch
+from .util import (
+    E_WORKSPACE_MISSING,
+    die,
+    gh,
+    git,
+    info,
+    out,
+)
+
+_WS_NAME_RE = re.compile(r"^(?P<repo>[A-Za-z0-9_.-]+)-issue-(?P<n>\d+)$")
+_REMOTE_GITHUB = re.compile(
+    r"^(?:https://github\.com/|git@github\.com:)([^/]+)/([^/]+?)(?:\.git)?$"
+)
+
+
+@dataclass
+class Issue:
+    owner_repo: str
+    number: int
+    title: str
+    state: Literal["open", "closed", "unknown"]
+
+
+@dataclass
+class BranchState:
+    ahead: int
+    behind: int
+    dirty: bool
+    missing: bool
+
+
+@dataclass
+class RepoStatus:
+    name: str
+    worktree_present: bool
+    branch_state: Optional[BranchState]
+    prs: list[PR] = field(default_factory=list)
+
+
+@dataclass
+class Workspace:
+    dir_name: str
+    issue: Issue
+    branch: str
+    archivable: bool
+    repos: list[RepoStatus] = field(default_factory=list)
+
+
+def _home() -> Path:
+    home = os.environ.get("APP_EMPIRE_WORKTREES_HOME")
+    if not home:
+        die("$APP_EMPIRE_WORKTREES_HOME not set (run 'devkit doctor')",
+            code=E_WORKSPACE_MISSING)
+    home_path = Path(home)
+    if not home_path.is_dir():
+        die(f"$APP_EMPIRE_WORKTREES_HOME is not a directory: {home}",
+            code=E_WORKSPACE_MISSING)
+    return home_path.resolve()
+
+
+def _enumerate_workspaces(home: Path) -> list[Path]:
+    entries: list[Path] = []
+    for child in sorted(home.iterdir()):
+        if not child.is_dir():
+            continue
+        if child.name.startswith("_"):
+            continue
+        if _WS_NAME_RE.match(child.name):
+            entries.append(child)
+    return entries
+
+
+def _parse_dir_name(dir_name: str) -> Optional[tuple[str, int]]:
+    m = _WS_NAME_RE.match(dir_name)
+    if not m:
+        return None
+    return m.group("repo"), int(m.group("n"))
+
+
+def _parse_owner_repo_from_url(url: str) -> Optional[str]:
+    m = _REMOTE_GITHUB.match(url)
+    if not m:
+        return None
+    return f"{m.group(1)}/{m.group(2)}"
+
+
+def _discover_repo_worktrees(workspace: Path) -> list[tuple[str, Path, Path]]:
+    """Return list of (subdir_name, worktree_path, upstream_root) for each repo.
+
+    `upstream_root` may not exist on disk if the user deleted it externally;
+    the caller signals `worktree_present=False` in that case.
+    """
+    found: list[tuple[str, Path, Path]] = []
+    if not workspace.is_dir():
+        return found
+    for subdir in sorted(workspace.iterdir()):
+        if not subdir.is_dir():
+            continue
+        if subdir.name in ("specs", ".git"):
+            continue
+        dotgit = subdir / ".git"
+        if not dotgit.is_file():
+            continue
+        content = dotgit.read_text(errors="replace").strip()
+        m = re.match(r"gitdir:\s*(.+)$", content)
+        if not m:
+            continue
+        try:
+            worktree_gitdir = Path(m.group(1)).resolve()
+            upstream_root = worktree_gitdir.parent.parent.parent
+        except Exception:
+            continue
+        found.append((subdir.name, subdir, upstream_root))
+    return found
+
+
+def _resolve_owner_repo(upstream_root: Path) -> Optional[str]:
+    if not upstream_root.is_dir():
+        return None
+    res = git("remote", "get-url", "origin", cwd=upstream_root)
+    if res.code != 0:
+        return None
+    return _parse_owner_repo_from_url(res.stdout.strip())
+
+
+def _collect_branch_state(worktree: Path, branch: str) -> Optional[BranchState]:
+    """Collect BranchState via git. Returns None if the worktree is unusable."""
+    if not worktree.is_dir():
+        return None
+    dotgit = worktree / ".git"
+    if not dotgit.exists():
+        return None
+
+    status_res = git("status", "--porcelain", cwd=worktree)
+    if status_res.code != 0:
+        return BranchState(ahead=0, behind=0, dirty=False, missing=True)
+    dirty = bool(status_res.stdout.strip())
+
+    branch_res = git("rev-parse", "--abbrev-ref", "HEAD", cwd=worktree)
+    current_branch = branch_res.stdout.strip() if branch_res.code == 0 else ""
+    missing = current_branch in ("", "HEAD")
+
+    upstream_ref = f"origin/{branch}"
+    rev_res = git(
+        "rev-list", "--left-right", "--count", f"{upstream_ref}...HEAD",
+        cwd=worktree,
+    )
+    ahead = 0
+    behind = 0
+    if rev_res.code == 0:
+        parts = rev_res.stdout.strip().split()
+        if len(parts) == 2:
+            try:
+                behind = int(parts[0])
+                ahead = int(parts[1])
+            except ValueError:
+                pass
+    else:
+        missing = True
+
+    return BranchState(ahead=ahead, behind=behind, dirty=dirty, missing=missing)
+
+
+def _collect_issue(owner_repo: str, number: int) -> Issue:
+    res = gh(
+        "issue", "view", str(number),
+        "--repo", owner_repo,
+        "--json", "state,title",
+    )
+    if res.code != 0:
+        return Issue(owner_repo=owner_repo, number=number, title="", state="unknown")
+    try:
+        payload = json.loads(res.stdout or "{}")
+    except json.JSONDecodeError:
+        return Issue(owner_repo=owner_repo, number=number, title="", state="unknown")
+    raw_state = (payload.get("state") or "").upper()
+    if raw_state == "OPEN":
+        state: Literal["open", "closed", "unknown"] = "open"
+    elif raw_state == "CLOSED":
+        state = "closed"
+    else:
+        state = "unknown"
+    return Issue(
+        owner_repo=owner_repo,
+        number=number,
+        title=str(payload.get("title") or ""),
+        state=state,
+    )
+
+
+def _derive_archivable(workspace: Workspace) -> bool:
+    if workspace.issue.state != "closed":
+        return False
+    if not workspace.repos:
+        return False
+    for repo in workspace.repos:
+        if not any(pr.state == "merged" for pr in repo.prs):
+            return False
+    return True
+
+
+def _build_workspace(workspace_dir: Path) -> Optional[Workspace]:
+    parsed = _parse_dir_name(workspace_dir.name)
+    if parsed is None:
+        return None
+    home_repo, issue_num = parsed
+    branch = f"issue-{home_repo}-{issue_num}"
+
+    worktrees = _discover_repo_worktrees(workspace_dir)
+
+    owner_for_home: Optional[str] = None
+    resolved: list[tuple[str, Path, Optional[str]]] = []
+    for subdir_name, wt_path, upstream_root in worktrees:
+        owner_repo = _resolve_owner_repo(upstream_root)
+        resolved.append((subdir_name, wt_path, owner_repo))
+        if owner_for_home is None and owner_repo is not None:
+            candidate_owner, candidate_repo = owner_repo.split("/", 1)
+            if candidate_repo == home_repo:
+                owner_for_home = candidate_owner
+
+    if owner_for_home is None:
+        for _, _, owner_repo in resolved:
+            if owner_repo is not None:
+                owner_for_home = owner_repo.split("/", 1)[0]
+                break
+
+    if owner_for_home is None:
+        issue = Issue(
+            owner_repo=f"?/{home_repo}",
+            number=issue_num,
+            title="",
+            state="unknown",
+        )
+    else:
+        issue = _collect_issue(f"{owner_for_home}/{home_repo}", issue_num)
+
+    repos_with_owner: list[tuple[str, Path]] = [
+        (owner_repo, wt_path)
+        for _, wt_path, owner_repo in resolved
+        if owner_repo is not None
+    ]
+    if repos_with_owner and issue.state != "unknown":
+        per_repo_prs = prs_for_branch(repos_with_owner, branch)
+    else:
+        per_repo_prs = {owner_repo: [] for owner_repo, _ in repos_with_owner}
+
+    repo_statuses: list[RepoStatus] = []
+    for subdir_name, wt_path, owner_repo in resolved:
+        branch_state = _collect_branch_state(wt_path, branch)
+        worktree_present = branch_state is not None
+        prs = per_repo_prs.get(owner_repo, []) if owner_repo else []
+        repo_statuses.append(
+            RepoStatus(
+                name=subdir_name,
+                worktree_present=worktree_present,
+                branch_state=branch_state,
+                prs=prs,
+            )
+        )
+
+    ws = Workspace(
+        dir_name=workspace_dir.name,
+        issue=issue,
+        branch=branch,
+        archivable=False,
+        repos=repo_statuses,
+    )
+    ws.archivable = _derive_archivable(ws)
+    return ws
+
+
+def _build_workspaces(home: Path) -> list[Workspace]:
+    dirs = _enumerate_workspaces(home)
+    if not dirs:
+        return []
+    results: list[Workspace] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        futures = {pool.submit(_build_workspace, d): d for d in dirs}
+        for fut in concurrent.futures.as_completed(futures):
+            ws = fut.result()
+            if ws is not None:
+                results.append(ws)
+    results.sort(key=lambda w: w.dir_name)
+    return results
+
+
+def _render_json(workspaces: list[Workspace]) -> None:
+    payload = {
+        "version": 1,
+        "workspaces": [_workspace_to_dict(w) for w in workspaces],
+    }
+    out.print(json.dumps(payload, indent=2))
+
+
+def _workspace_to_dict(w: Workspace) -> dict:
+    return {
+        "dir_name": w.dir_name,
+        "issue": dataclasses.asdict(w.issue),
+        "branch": w.branch,
+        "archivable": w.archivable,
+        "repos": [_repo_to_dict(r) for r in w.repos],
+    }
+
+
+def _repo_to_dict(r: RepoStatus) -> dict:
+    return {
+        "name": r.name,
+        "worktree_present": r.worktree_present,
+        "branch_state": dataclasses.asdict(r.branch_state) if r.branch_state else None,
+        "prs": [dataclasses.asdict(pr) for pr in r.prs],
+    }
+
+
+def _render_text(workspaces: list[Workspace]) -> None:
+    if not workspaces:
+        info("no active workspaces found under $APP_EMPIRE_WORKTREES_HOME")
+        return
+    for w in workspaces:
+        archivable_tag = " [archivable]" if w.archivable else ""
+        out.print(
+            f"{w.dir_name}  {w.issue.owner_repo}#{w.issue.number} "
+            f"({w.issue.state}){archivable_tag}"
+        )
+        if w.issue.title:
+            out.print(f"  title: {w.issue.title}")
+        for r in w.repos:
+            if not r.worktree_present or r.branch_state is None:
+                out.print(f"  {r.name:<16} worktree: MISSING")
+            else:
+                bs = r.branch_state
+                parts = [f"ahead {bs.ahead}", f"behind {bs.behind}"]
+                if bs.dirty:
+                    parts.append("dirty")
+                if bs.missing:
+                    parts.append("branch-missing")
+                out.print(f"  {r.name:<16} " + "  ".join(parts))
+            if r.prs:
+                for pr in r.prs:
+                    out.print(f"    PR #{pr.number:<6} {pr.state:<8} {pr.url}")
 
 
 def cmd_status(json_output: bool) -> int:
-    log("status: not yet implemented")
+    home = _home()
+    workspaces = _build_workspaces(home)
+    if json_output:
+        _render_json(workspaces)
+    else:
+        _render_text(workspaces)
     return 0

--- a/src/aidevkit/uninstall.py
+++ b/src/aidevkit/uninstall.py
@@ -1,0 +1,9 @@
+"""`devkit uninstall` — stub; real implementation lands in US4 phase."""
+from __future__ import annotations
+
+from .util import log
+
+
+def cmd_uninstall() -> int:
+    log("uninstall: not yet implemented")
+    return 0

--- a/src/aidevkit/uninstall.py
+++ b/src/aidevkit/uninstall.py
@@ -1,9 +1,90 @@
-"""`devkit uninstall` — stub; real implementation lands in US4 phase."""
+"""`devkit uninstall` — remove DevKit: unlink slash commands, then `uv tool uninstall`.
+
+Never touches user data (active workspaces, `_archived/`, `.devkit/` dirs).
+Detects DevKit-installed slash commands by resolving each `~/.claude/commands/*.md`
+symlink and filtering by target containing `/aidevkit/commands/`. Non-`uv-tool`
+installs exit with a clear guidance message rather than running a `uv` command
+that would fail.
+"""
 from __future__ import annotations
 
-from .util import log
+from pathlib import Path
+
+from . import util
+from ._install import detect_install_info
+from .util import (
+    E_INSTALL_NOT_UV_TOOL,
+    die,
+    info,
+    log,
+)
+
+_MARKER_PATH_FRAGMENT = "/aidevkit/commands/"
+
+
+def _cmd_dir() -> Path:
+    return Path.home() / ".claude" / "commands"
+
+
+def _devkit_symlinks(cmd_dir: Path) -> list[Path]:
+    """Return `~/.claude/commands/*.md` entries whose resolved target is inside
+    an `aidevkit/commands/` directory (i.e., installed by `devkit setup`).
+    """
+    if not cmd_dir.is_dir():
+        return []
+    found: list[Path] = []
+    for entry in sorted(cmd_dir.iterdir()):
+        if not entry.is_symlink():
+            continue
+        if not entry.name.endswith(".md"):
+            continue
+        try:
+            target = entry.resolve()
+        except (OSError, RuntimeError):
+            continue
+        if _MARKER_PATH_FRAGMENT in str(target):
+            found.append(entry)
+    return found
 
 
 def cmd_uninstall() -> int:
-    log("uninstall: not yet implemented")
+    info_ = detect_install_info()
+    if not info_.manageable:
+        die(
+            f"install method is '{info_.method}', which devkit cannot manage. "
+            f"Uninstall manually: for pip use `pip uninstall aidevkit`; for a "
+            f"source checkout just delete the repo and remove the devkit "
+            f"symlinks under ~/.claude/commands/.",
+            code=E_INSTALL_NOT_UV_TOOL,
+        )
+
+    cmd_dir = _cmd_dir()
+    links = _devkit_symlinks(cmd_dir)
+    removed = 0
+    for link in links:
+        try:
+            link.unlink()
+            removed += 1
+        except OSError as exc:
+            log(f"WARN: could not unlink {link}: {exc}")
+
+    result = util.run(["uv", "tool", "uninstall", "aidevkit"])
+    if result.code != 0:
+        # `uv tool uninstall` of an already-gone package is the idempotent path
+        # (FR-SELF "nothing to do"). Treat non-zero exit as a soft signal and
+        # surface the stderr but still return 0 if the message looks like
+        # already-absent. Otherwise propagate.
+        stderr = (result.stderr or result.stdout or "").lower()
+        if "not installed" in stderr or "no such tool" in stderr:
+            info("aidevkit was already uninstalled.")
+            info(f"Removed {removed} DevKit slash command symlink(s) from {cmd_dir}.")
+            return 0
+        log(result.stderr.strip() or result.stdout.strip())
+        return result.code
+
+    info(
+        f"Uninstalled aidevkit {info_.installed_version or ''}"
+        f" and removed {removed} slash command symlink(s) from {cmd_dir}."
+    )
+    info("User data under $APP_EMPIRE_WORKTREES_HOME was not touched.")
     return 0

--- a/src/aidevkit/update.py
+++ b/src/aidevkit/update.py
@@ -1,9 +1,50 @@
-"""`devkit update` — stub; real implementation lands in US4 phase."""
+"""`devkit update` — `uv tool upgrade aidevkit`, then run `devkit doctor`.
+
+No rollback on doctor failure (FR-SELF-005 / R-12). The upgrade succeeded;
+doctor's findings are surfaced verbatim and the command exits with doctor's
+exit code so the failure is loud.
+"""
 from __future__ import annotations
 
-from .util import log
+from . import doctor as doctor_mod
+from . import util
+from ._install import detect_install_info
+from .util import (
+    E_INSTALL_NOT_UV_TOOL,
+    die,
+    info,
+    log,
+)
 
 
 def cmd_update() -> int:
-    log("update: not yet implemented")
-    return 0
+    before = detect_install_info()
+    if not before.manageable:
+        die(
+            f"install method is '{before.method}', which devkit cannot manage. "
+            f"Upgrade manually: for pip use `pip install --upgrade aidevkit`; "
+            f"for a source checkout pull + reinstall from the repo.",
+            code=E_INSTALL_NOT_UV_TOOL,
+        )
+
+    info(f"Current version: aidevkit {before.installed_version or 'unknown'}")
+    upgrade = util.run(["uv", "tool", "upgrade", "aidevkit"])
+    if upgrade.code != 0:
+        log(
+            "uv tool upgrade failed: "
+            + (upgrade.stderr.strip() or upgrade.stdout.strip() or "unknown error")
+        )
+        return upgrade.code
+    if upgrade.stdout:
+        info(upgrade.stdout.strip())
+
+    after = detect_install_info()
+    before_v = before.installed_version or "unknown"
+    after_v = after.installed_version or "unknown"
+    if before_v != after_v:
+        info(f"[devkit] aidevkit {before_v} → {after_v}")
+    else:
+        info(f"[devkit] aidevkit already at {after_v}")
+
+    info("Running devkit doctor…")
+    return doctor_mod.cmd_doctor()

--- a/src/aidevkit/update.py
+++ b/src/aidevkit/update.py
@@ -1,0 +1,9 @@
+"""`devkit update` — stub; real implementation lands in US4 phase."""
+from __future__ import annotations
+
+from .util import log
+
+
+def cmd_update() -> int:
+    log("update: not yet implemented")
+    return 0

--- a/src/aidevkit/util.py
+++ b/src/aidevkit/util.py
@@ -29,6 +29,9 @@ E_NOT_IN_WORKSPACE = 20
 E_SYNC_PARTIAL = 21
 E_BEHIND_ORIGIN = 22
 E_PREFLIGHT_FAILED = 23
+E_NOT_IN_PER_ISSUE_WORKSPACE = 24
+E_INSTALL_NOT_UV_TOOL = 26
+E_CHECK_UPDATE_INDEX_UNAVAILABLE = 27
 
 out = Console(markup=False, highlight=False, soft_wrap=True)
 err = Console(stderr=True, markup=False, highlight=False, soft_wrap=True)

--- a/tests/integration/test_add_repo_end_to_end.py
+++ b/tests/integration/test_add_repo_end_to_end.py
@@ -1,0 +1,75 @@
+"""Integration test for `devkit add-repo`: real git + real filesystem."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from aidevkit import add_repo as add_repo_mod
+from aidevkit.util import RunResult
+
+
+def _real_run(cmd: list[str], *, check: bool = False, cwd: Path | None = None) -> RunResult:
+    proc = subprocess.run(
+        cmd, cwd=cwd, capture_output=True, text=True, check=check,
+    )
+    return RunResult(code=proc.returncode, stdout=proc.stdout, stderr=proc.stderr)
+
+
+def test_add_repo_creates_real_git_worktree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Seed a real source repo
+    projects = tmp_path / "projects"
+    projects.mkdir()
+    source = projects / "AuthService"
+    source.mkdir()
+    for cmd in (
+        ["git", "init", "--initial-branch=main"],
+        ["git", "config", "user.email", "t@t.t"],
+        ["git", "config", "user.name", "T"],
+    ):
+        subprocess.run(cmd, cwd=source, check=True, capture_output=True)
+    (source / "README.md").write_text("hello\n")
+    subprocess.run(["git", "add", "."], cwd=source, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "seed"],
+        cwd=source, check=True, capture_output=True,
+    )
+
+    # Build the per-issue workspace
+    home = tmp_path / "worktrees_home"
+    home.mkdir()
+    workspace = home / "DevKit-issue-77"
+    workspace.mkdir()
+
+    monkeypatch.setenv("APP_EMPIRE_WORKTREES_HOME", str(home))
+    monkeypatch.setenv("APP_EMPIRE_PROJECTS", str(projects))
+    monkeypatch.chdir(workspace)
+    monkeypatch.setattr("aidevkit.util.run", _real_run)
+
+    exit_code = add_repo_mod.cmd_add_repo("AuthService")
+    assert exit_code == 0
+
+    target = workspace / "AuthService"
+    assert target.is_dir()
+    assert (target / ".git").is_file()
+
+    # Verify registration in source via `git worktree list`
+    listing = subprocess.run(
+        ["git", "worktree", "list"],
+        cwd=source, check=True, capture_output=True, text=True,
+    )
+    assert str(target) in listing.stdout
+
+    # Re-run → idempotent skip
+    second = add_repo_mod.cmd_add_repo("AuthService")
+    assert second == 0
+    # Worktree still exists, no duplicate registration
+    listing2 = subprocess.run(
+        ["git", "worktree", "list"],
+        cwd=source, check=True, capture_output=True, text=True,
+    )
+    # Count occurrences — still exactly one matching line
+    assert listing2.stdout.count(str(target)) == 1

--- a/tests/integration/test_archive_end_to_end.py
+++ b/tests/integration/test_archive_end_to_end.py
@@ -149,6 +149,10 @@ def test_archive_happy_path_real_git(
     assert archived.is_dir(), "archived dir should exist"
     assert (archived / "specs" / "77-test" / "spec.md").is_file()
     assert (archived / "Upstream").is_dir()
+    marker = archived / ".devkit-archived"
+    assert marker.is_file(), "archive must drop a .devkit-archived marker"
+    import datetime as _dt
+    _dt.datetime.fromisoformat(marker.read_text().strip())
 
     # Prune should have cleaned the stale registration
     list_after = subprocess.run(

--- a/tests/integration/test_purge_end_to_end.py
+++ b/tests/integration/test_purge_end_to_end.py
@@ -1,0 +1,60 @@
+"""Integration test for `devkit purge`: real filesystem, mixed marker states."""
+from __future__ import annotations
+
+import datetime
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from aidevkit import purge as purge_mod
+from aidevkit.util import RunResult
+
+
+def _real_run(cmd: list[str], *, check: bool = False, cwd: Path | None = None) -> RunResult:
+    proc = subprocess.run(
+        cmd, cwd=cwd, capture_output=True, text=True, check=check,
+    )
+    return RunResult(code=proc.returncode, stdout=proc.stdout, stderr=proc.stderr)
+
+
+def test_purge_mixed_marker_states_real_fs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    archived = home / "_archived"
+    archived.mkdir()
+
+    old = archived / "OldDir"
+    old.mkdir()
+    old_ts = (datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=60))
+    (old / ".devkit-archived").write_text(
+        old_ts.strftime("%Y-%m-%dT%H:%M:%SZ") + "\n"
+    )
+    (old / "some-file.txt").write_text("content")
+
+    young = archived / "YoungDir"
+    young.mkdir()
+    young_ts = (datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=5))
+    (young / ".devkit-archived").write_text(
+        young_ts.strftime("%Y-%m-%dT%H:%M:%SZ") + "\n"
+    )
+
+    no_marker = archived / "NoMarker"
+    no_marker.mkdir()
+    (no_marker / "file.txt").write_text("x")
+
+    active = home / "Active-issue-1"
+    active.mkdir()
+
+    monkeypatch.setenv("APP_EMPIRE_WORKTREES_HOME", str(home))
+    monkeypatch.setattr("aidevkit.util.run", _real_run)
+
+    exit_code = purge_mod.cmd_purge(days=30, yes=True)
+    assert exit_code == 0
+
+    assert not old.exists(), "old marker-present dir should be deleted"
+    assert young.exists(), "young dir should be preserved"
+    assert no_marker.exists(), "no-marker dir must never be touched"
+    assert active.exists(), "active workspace must never be touched"

--- a/tests/test_add_repo.py
+++ b/tests/test_add_repo.py
@@ -1,0 +1,261 @@
+"""Tests for `devkit add-repo`."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from aidevkit import add_repo as add_repo_mod
+from aidevkit.cli import app
+from aidevkit.util import (
+    E_NOT_IN_PER_ISSUE_WORKSPACE,
+    E_REPO_NOT_FOUND,
+    E_WORKSPACE_MISSING,
+    RunResult,
+)
+
+
+@pytest.fixture
+def runner(monkeypatch: pytest.MonkeyPatch) -> CliRunner:
+    monkeypatch.setenv("NO_COLOR", "1")
+    return CliRunner()
+
+
+# --- PerIssueContext detection ------------------------------------------------
+
+
+def test_detect_context_direct_workspace(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    workspace = home / "DevKit-issue-20"
+    workspace.mkdir()
+    ctx = add_repo_mod._detect_per_issue_context(workspace, home)
+    assert ctx.home_repo_name == "DevKit"
+    assert ctx.issue_number == 20
+    assert ctx.branch == "issue-DevKit-20"
+
+
+def test_detect_context_nested_subdir(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    workspace = home / "DevKit-issue-20"
+    nested = workspace / "DevKit" / "src"
+    nested.mkdir(parents=True)
+    ctx = add_repo_mod._detect_per_issue_context(nested, home)
+    assert ctx.home_repo_name == "DevKit"
+    assert ctx.workspace_dir == workspace.resolve()
+
+
+def test_detect_context_outside_exits_24(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    outside = tmp_path / "somewhere_else"
+    outside.mkdir()
+    with pytest.raises(typer.Exit) as excinfo:
+        add_repo_mod._detect_per_issue_context(outside, home)
+    assert excinfo.value.exit_code == E_NOT_IN_PER_ISSUE_WORKSPACE
+
+
+def test_detect_context_archived_does_not_match(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    archived = home / "_archived"
+    archived.mkdir()
+    old = archived / "DevKit-issue-1"
+    old.mkdir()
+    with pytest.raises(typer.Exit):
+        add_repo_mod._detect_per_issue_context(old, home)
+
+
+# --- Source-repo resolution ---------------------------------------------------
+
+
+def test_resolve_source_repo_returns_path(tmp_path: Path) -> None:
+    projects = tmp_path / "projects"
+    (projects / "Repo").mkdir(parents=True)
+    assert add_repo_mod._resolve_source_repo("Repo", projects) == projects / "Repo"
+
+
+def test_resolve_source_repo_missing_exits_13(tmp_path: Path) -> None:
+    projects = tmp_path / "projects"
+    projects.mkdir()
+    with pytest.raises(typer.Exit) as excinfo:
+        add_repo_mod._resolve_source_repo("NoSuch", projects)
+    assert excinfo.value.exit_code == E_REPO_NOT_FOUND
+
+
+# --- Idempotent skip ----------------------------------------------------------
+
+
+def test_target_points_into_detects_valid_worktree(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    (source / ".git" / "worktrees" / "Copy").mkdir(parents=True)
+    target = tmp_path / "home" / "Repo-issue-1" / "Copy"
+    target.mkdir(parents=True)
+    (target / ".git").write_text(f"gitdir: {source}/.git/worktrees/Copy\n")
+    assert add_repo_mod._target_points_into(source, target) is True
+
+
+def test_target_points_into_rejects_unrelated_gitdir(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    other = tmp_path / "other"
+    other.mkdir()
+    target = tmp_path / "home" / "Repo-issue-1" / "Copy"
+    target.mkdir(parents=True)
+    (target / ".git").write_text(f"gitdir: {other}/.git/worktrees/Copy\n")
+    assert add_repo_mod._target_points_into(source, target) is False
+
+
+# --- End-to-end via CLI -------------------------------------------------------
+
+
+def _setup_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> tuple[Path, Path, Path]:
+    home = tmp_path / "home"
+    home.mkdir()
+    projects = tmp_path / "projects"
+    projects.mkdir()
+    workspace = home / "DevKit-issue-20"
+    workspace.mkdir()
+    monkeypatch.setenv("APP_EMPIRE_WORKTREES_HOME", str(home))
+    monkeypatch.setenv("APP_EMPIRE_PROJECTS", str(projects))
+    monkeypatch.chdir(workspace)
+    return home, projects, workspace
+
+
+def test_add_repo_creates_worktree_when_branch_exists(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home, projects, workspace = _setup_env(monkeypatch, tmp_path)
+    source = projects / "AuthService"
+    source.mkdir()
+
+    calls: list[list[str]] = []
+
+    def shell(cmd: list[str], **_: object) -> RunResult:
+        calls.append(list(cmd))
+        if cmd[:2] == ["git", "show-ref"]:
+            return RunResult(code=0, stdout="abc refs/heads/issue-DevKit-20\n", stderr="")
+        if cmd[:3] == ["git", "worktree", "add"]:
+            return RunResult(code=0, stdout="", stderr="")
+        return RunResult(code=0, stdout="", stderr="")
+
+    monkeypatch.setattr("aidevkit.util.run", shell)
+    result = runner.invoke(app, ["add-repo", "AuthService"])
+    assert result.exit_code == 0, result.output
+    wt_cmd = [c for c in calls if c[:3] == ["git", "worktree", "add"]]
+    assert len(wt_cmd) == 1
+    # branch existed → no `-b` flag
+    assert "-b" not in wt_cmd[0]
+
+
+def test_add_repo_creates_branch_when_absent(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home, projects, workspace = _setup_env(monkeypatch, tmp_path)
+    (projects / "AuthService").mkdir()
+
+    calls: list[list[str]] = []
+
+    def shell(cmd: list[str], **_: object) -> RunResult:
+        calls.append(list(cmd))
+        if cmd[:2] == ["git", "show-ref"]:
+            return RunResult(code=1, stdout="", stderr="not found")
+        if cmd[:3] == ["git", "worktree", "add"]:
+            return RunResult(code=0, stdout="", stderr="")
+        return RunResult(code=0, stdout="", stderr="")
+
+    monkeypatch.setattr("aidevkit.util.run", shell)
+    result = runner.invoke(app, ["add-repo", "AuthService"])
+    assert result.exit_code == 0, result.output
+    wt_cmd = [c for c in calls if c[:3] == ["git", "worktree", "add"]]
+    assert len(wt_cmd) == 1
+    assert "-b" in wt_cmd[0]
+    assert "issue-DevKit-20" in wt_cmd[0]
+
+
+def test_add_repo_idempotent_skip(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home, projects, workspace = _setup_env(monkeypatch, tmp_path)
+    source = projects / "AuthService"
+    (source / ".git" / "worktrees" / "AuthService").mkdir(parents=True)
+    target = workspace / "AuthService"
+    target.mkdir()
+    (target / ".git").write_text(f"gitdir: {source}/.git/worktrees/AuthService\n")
+
+    wt_add_calls: list[list[str]] = []
+
+    def shell(cmd: list[str], **_: object) -> RunResult:
+        if cmd[:3] == ["git", "worktree", "add"]:
+            wt_add_calls.append(list(cmd))
+        return RunResult(code=0, stdout="", stderr="")
+
+    monkeypatch.setattr("aidevkit.util.run", shell)
+    result = runner.invoke(app, ["add-repo", "AuthService"])
+    assert result.exit_code == 0, result.output
+    assert wt_add_calls == [], "idempotent skip must not invoke git worktree add"
+
+
+def test_add_repo_missing_source_exits_13(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home, projects, workspace = _setup_env(monkeypatch, tmp_path)
+
+    def shell(cmd: list[str], **_: object) -> RunResult:
+        return RunResult(code=0, stdout="", stderr="")
+
+    monkeypatch.setattr("aidevkit.util.run", shell)
+    result = runner.invoke(app, ["add-repo", "NotThere"])
+    assert result.exit_code == E_REPO_NOT_FOUND
+
+
+def test_add_repo_outside_workspace_exits_24(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    projects = tmp_path / "projects"
+    projects.mkdir()
+    (projects / "AuthService").mkdir()
+    outside = tmp_path / "random"
+    outside.mkdir()
+    monkeypatch.setenv("APP_EMPIRE_WORKTREES_HOME", str(home))
+    monkeypatch.setenv("APP_EMPIRE_PROJECTS", str(projects))
+    monkeypatch.chdir(outside)
+
+    def shell(cmd: list[str], **_: object) -> RunResult:
+        return RunResult(code=0, stdout="", stderr="")
+
+    monkeypatch.setattr("aidevkit.util.run", shell)
+    result = runner.invoke(app, ["add-repo", "AuthService"])
+    assert result.exit_code == E_NOT_IN_PER_ISSUE_WORKSPACE
+
+
+def test_add_repo_missing_env_exits_16(
+    runner: CliRunner,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("APP_EMPIRE_WORKTREES_HOME", raising=False)
+    monkeypatch.delenv("APP_EMPIRE_PROJECTS", raising=False)
+
+    def shell(cmd: list[str], **_: object) -> RunResult:
+        return RunResult(code=0, stdout="", stderr="")
+
+    monkeypatch.setattr("aidevkit.util.run", shell)
+    result = runner.invoke(app, ["add-repo", "Any"])
+    assert result.exit_code == E_WORKSPACE_MISSING

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,6 +1,7 @@
 """Tests for the archive subcommand — resolution, PR checks, spec discovery, mv + prune."""
 from __future__ import annotations
 
+import datetime
 import json
 from pathlib import Path
 
@@ -296,6 +297,22 @@ def test_move_to_archived_creates_archived_root(tmp_path: Path) -> None:
     assert (dest / "marker").read_text() == "test"
 
 
+def test_move_to_archived_writes_devkit_archived_marker(tmp_path: Path) -> None:
+    worktrees = tmp_path / "worktrees"
+    worktrees.mkdir()
+    workspace = worktrees / "DevKit-issue-4"
+    workspace.mkdir()
+
+    dest = archive_mod._move_to_archived(workspace)
+    marker = dest / ".devkit-archived"
+    assert marker.is_file(), "archive must drop a .devkit-archived marker"
+    raw = marker.read_text().strip()
+    parsed = datetime.datetime.fromisoformat(raw)
+    now = datetime.datetime.now(datetime.UTC)
+    # Generous skew window — CI clocks wobble.
+    assert abs((now - parsed).total_seconds()) < 60
+
+
 def test_prune_worktrees_runs_prune_per_upstream(
     tmp_path: Path,
     subprocess_capture,
@@ -398,6 +415,9 @@ def test_happy_path_cli_exits_zero_and_moves_worktree(
     assert not workspace.exists()
     archived = workspace.parent / "_archived" / "DevKit-issue-4"
     assert archived.is_dir()
+    marker = archived / ".devkit-archived"
+    assert marker.is_file()
+    datetime.datetime.fromisoformat(marker.read_text().strip())
 
 
 def test_happy_path_dry_run_makes_no_mutations(

--- a/tests/test_check_update.py
+++ b/tests/test_check_update.py
@@ -1,0 +1,91 @@
+"""Tests for `devkit check-update`."""
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from aidevkit.cli import app
+from aidevkit.util import E_CHECK_UPDATE_INDEX_UNAVAILABLE, RunResult
+
+
+@pytest.fixture
+def runner(monkeypatch: pytest.MonkeyPatch) -> CliRunner:
+    monkeypatch.setenv("NO_COLOR", "1")
+    return CliRunner()
+
+
+def test_check_update_update_available(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def shell(cmd: list[str], **_: object) -> RunResult:
+        if cmd[:3] == ["uv", "tool", "list"]:
+            return RunResult(code=0, stdout="aidevkit v0.2.0\n", stderr="")
+        if cmd[:4] == ["uv", "tool", "upgrade", "--dry-run"]:
+            return RunResult(
+                code=0, stdout="Would install aidevkit==0.3.0\n", stderr=""
+            )
+        return RunResult(code=0, stdout="", stderr="")
+
+    monkeypatch.setattr("aidevkit.util.run", shell)
+    result = runner.invoke(app, ["check-update"])
+    assert result.exit_code == 0, result.output
+    assert "0.2.0 → 0.3.0" in result.output
+
+
+def test_check_update_up_to_date(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def shell(cmd: list[str], **_: object) -> RunResult:
+        if cmd[:3] == ["uv", "tool", "list"]:
+            return RunResult(code=0, stdout="aidevkit v0.3.0\n", stderr="")
+        if cmd[:4] == ["uv", "tool", "upgrade", "--dry-run"]:
+            return RunResult(code=0, stdout="aidevkit is up to date\n", stderr="")
+        return RunResult(code=0, stdout="", stderr="")
+
+    monkeypatch.setattr("aidevkit.util.run", shell)
+    result = runner.invoke(app, ["check-update"])
+    assert result.exit_code == 0, result.output
+    assert "up to date" in result.output.lower()
+
+
+def test_check_update_parse_failure_exits_27(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def shell(cmd: list[str], **_: object) -> RunResult:
+        if cmd[:3] == ["uv", "tool", "list"]:
+            return RunResult(code=0, stdout="aidevkit v0.3.0\n", stderr="")
+        if cmd[:4] == ["uv", "tool", "upgrade", "--dry-run"]:
+            return RunResult(
+                code=1, stdout="", stderr="error: index unreachable\n"
+            )
+        return RunResult(code=0, stdout="", stderr="")
+
+    monkeypatch.setattr("aidevkit.util.run", shell)
+    result = runner.invoke(app, ["check-update"])
+    assert result.exit_code == E_CHECK_UPDATE_INDEX_UNAVAILABLE
+
+
+def test_check_update_json_output_shape(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def shell(cmd: list[str], **_: object) -> RunResult:
+        if cmd[:3] == ["uv", "tool", "list"]:
+            return RunResult(code=0, stdout="aidevkit v0.2.0\n", stderr="")
+        if cmd[:4] == ["uv", "tool", "upgrade", "--dry-run"]:
+            return RunResult(
+                code=0, stdout="Would install aidevkit==0.3.0\n", stderr=""
+            )
+        return RunResult(code=0, stdout="", stderr="")
+
+    monkeypatch.setattr("aidevkit.util.run", shell)
+    result = runner.invoke(app, ["check-update", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload == {
+        "installed": "0.2.0",
+        "latest": "0.3.0",
+        "update_available": True,
+        "unresolvable_reason": None,
+    }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,18 +24,26 @@ EXPECTED_HELP = """\
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ bootstrap  Create a per-issue workspace directory with per-repo git          │
-│            worktrees.                                                        │
-│ doctor     Check dependencies, required env vars, and gh authentication.     │
-│ setup      Link DevKit slash commands into ~/.claude/commands/ (runs doctor  │
-│            first).                                                           │
-│ sync       Fetch and rebase every worktree in the current workspace onto its │
-│            trunk.                                                            │
-│ archive    Archive a completed per-issue workspace: post spec as issue       │
-│            comment, move worktree to _archived/, prune registrations.        │
-│ preflight  Check whether the current issue branch is behind origin/main      │
-│            (detect-only; no mutation).                                       │
-│ version    Print the installed aidevkit version.                             │
+│ bootstrap     Create a per-issue workspace directory with per-repo git       │
+│               worktrees.                                                     │
+│ doctor        Check dependencies, required env vars, and gh authentication.  │
+│ setup         Link DevKit slash commands into ~/.claude/commands/ (runs      │
+│               doctor first).                                                 │
+│ sync          Fetch and rebase every worktree in the current workspace onto  │
+│               its trunk.                                                     │
+│ archive       Archive a completed per-issue workspace: post spec as issue    │
+│               comment, move worktree to _archived/, prune registrations.     │
+│ preflight     Check whether the current issue branch is behind origin/main   │
+│               (detect-only; no mutation).                                    │
+│ status        Summarize every active per-issue workspace: issue state,       │
+│               branches, PRs.                                                 │
+│ add-repo      Add a sibling repo's worktree to the current per-issue         │
+│               workspace.                                                     │
+│ purge         Remove archived workspaces older than the retention threshold. │
+│ uninstall     Remove DevKit: uninstall aidevkit and unlink slash commands.   │
+│ update        Upgrade DevKit to the latest release, then run doctor.         │
+│ check-update  Check whether a newer aidevkit release is available.           │
+│ version       Print the installed aidevkit version.                          │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 """
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,0 +1,62 @@
+"""Tests for the install-method detector (`_install.detect_install_info`)."""
+from __future__ import annotations
+
+from aidevkit import _install
+from aidevkit.util import RunResult
+
+
+def test_detects_uv_tool(subprocess_capture) -> None:
+    subprocess_capture.queue(
+        RunResult(code=0, stdout="aidevkit v0.3.0\n- devkit\n", stderr="")
+    )
+    info = _install.detect_install_info()
+    assert info.method == "uv-tool"
+    assert info.installed_version == "0.3.0"
+    assert info.manageable is True
+
+
+def test_detects_pip(subprocess_capture) -> None:
+    # uv tool list returns nothing matching
+    subprocess_capture.queue(RunResult(code=0, stdout="othertool v1.0\n", stderr=""))
+    subprocess_capture.queue(
+        RunResult(
+            code=0,
+            stdout=(
+                "Name: aidevkit\n"
+                "Version: 0.2.0\n"
+                "Location: /Users/x/.venv/lib/python3.11/site-packages\n"
+            ),
+            stderr="",
+        )
+    )
+    info = _install.detect_install_info()
+    assert info.method == "pip"
+    assert info.installed_version == "0.2.0"
+    assert info.manageable is False
+
+
+def test_detects_source_when_location_not_sitepackages(subprocess_capture) -> None:
+    subprocess_capture.queue(RunResult(code=0, stdout="", stderr=""))
+    subprocess_capture.queue(
+        RunResult(
+            code=0,
+            stdout=(
+                "Name: aidevkit\n"
+                "Version: 0.0.0+unknown\n"
+                "Location: /Users/x/code/DevKit/src\n"
+            ),
+            stderr="",
+        )
+    )
+    info = _install.detect_install_info()
+    assert info.method == "source"
+    assert info.manageable is False
+
+
+def test_detects_unknown_when_neither(subprocess_capture) -> None:
+    subprocess_capture.queue(RunResult(code=0, stdout="", stderr=""))
+    subprocess_capture.queue(RunResult(code=1, stdout="", stderr="not found"))
+    info = _install.detect_install_info()
+    assert info.method == "unknown"
+    assert info.installed_version is None
+    assert info.manageable is False

--- a/tests/test_prs.py
+++ b/tests/test_prs.py
@@ -1,0 +1,108 @@
+"""Tests for the shared `_prs` helpers."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aidevkit import _prs
+from aidevkit.util import RunResult
+
+
+def test_check_prs_merged_all_merged_returns_empty(subprocess_capture) -> None:
+    subprocess_capture.queue(
+        RunResult(
+            code=0,
+            stdout=json.dumps([{"number": 1, "state": "MERGED", "url": "https://x/1"}]),
+            stderr="",
+        )
+    )
+    blockers = _prs.check_prs_merged(
+        [("owner/Repo", Path("/tmp"))], "issue-Repo-1"
+    )
+    assert blockers == []
+
+
+def test_check_prs_merged_open_is_blocker(subprocess_capture) -> None:
+    subprocess_capture.queue(
+        RunResult(
+            code=0,
+            stdout=json.dumps([{"number": 2, "state": "OPEN", "url": "https://x/2"}]),
+            stderr="",
+        )
+    )
+    blockers = _prs.check_prs_merged(
+        [("owner/Repo", Path("/tmp"))], "issue-Repo-1"
+    )
+    assert len(blockers) == 1
+    assert "#2" in blockers[0] and "OPEN" in blockers[0]
+
+
+def test_check_prs_merged_gh_failure_is_blocker(subprocess_capture) -> None:
+    subprocess_capture.queue(RunResult(code=1, stdout="", stderr="boom"))
+    blockers = _prs.check_prs_merged(
+        [("owner/Repo", Path("/tmp"))], "issue-Repo-1"
+    )
+    assert len(blockers) == 1
+    assert "failed to query PRs" in blockers[0]
+
+
+def test_check_prs_merged_unparseable_is_blocker(subprocess_capture) -> None:
+    subprocess_capture.queue(RunResult(code=0, stdout="not json", stderr=""))
+    blockers = _prs.check_prs_merged(
+        [("owner/Repo", Path("/tmp"))], "issue-Repo-1"
+    )
+    assert len(blockers) == 1
+    assert "unparseable" in blockers[0]
+
+
+def test_prs_for_branch_normalizes_states(subprocess_capture) -> None:
+    subprocess_capture.queue(
+        RunResult(
+            code=0,
+            stdout=json.dumps(
+                [
+                    {"number": 10, "state": "MERGED", "url": "https://x/10"},
+                    {"number": 11, "state": "OPEN", "url": "https://x/11"},
+                    {"number": 12, "state": "CLOSED", "url": "https://x/12"},
+                ]
+            ),
+            stderr="",
+        )
+    )
+    result = _prs.prs_for_branch(
+        [("owner/Repo", Path("/tmp"))], "issue-Repo-1"
+    )
+    assert set(result.keys()) == {"owner/Repo"}
+    prs = result["owner/Repo"]
+    states = {pr.number: pr.state for pr in prs}
+    assert states == {10: "merged", 11: "open", 12: "closed"}
+
+
+def test_prs_for_branch_gh_failure_yields_empty_list(subprocess_capture) -> None:
+    subprocess_capture.queue(RunResult(code=1, stdout="", stderr="boom"))
+    result = _prs.prs_for_branch(
+        [("owner/Repo", Path("/tmp"))], "issue-Repo-1"
+    )
+    assert result == {"owner/Repo": []}
+
+
+def test_prs_for_branch_multiple_repos(subprocess_capture) -> None:
+    subprocess_capture.queue(
+        RunResult(code=0, stdout=json.dumps([
+            {"number": 1, "state": "MERGED", "url": "https://x/1"},
+        ]), stderr="")
+    )
+    subprocess_capture.queue(
+        RunResult(code=0, stdout=json.dumps([]), stderr="")
+    )
+    result = _prs.prs_for_branch(
+        [
+            ("owner/A", Path("/tmp/a")),
+            ("owner/B", Path("/tmp/b")),
+        ],
+        "issue-A-1",
+    )
+    assert list(result.keys()) == ["owner/A", "owner/B"]
+    assert len(result["owner/A"]) == 1
+    assert result["owner/A"][0].state == "merged"
+    assert result["owner/B"] == []

--- a/tests/test_purge.py
+++ b/tests/test_purge.py
@@ -1,0 +1,237 @@
+"""Tests for `devkit purge`."""
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from aidevkit import purge as purge_mod
+from aidevkit.cli import app
+from aidevkit.util import E_WORKSPACE_MISSING
+
+
+@pytest.fixture
+def runner(monkeypatch: pytest.MonkeyPatch) -> CliRunner:
+    monkeypatch.setenv("NO_COLOR", "1")
+    return CliRunner()
+
+
+def _make_archived(
+    home: Path,
+    name: str,
+    *,
+    marker_text: str | None,
+) -> Path:
+    archived_root = home / "_archived"
+    archived_root.mkdir(exist_ok=True)
+    path = archived_root / name
+    path.mkdir()
+    if marker_text is not None:
+        (path / ".devkit-archived").write_text(marker_text)
+    return path
+
+
+def _iso(days_ago: int) -> str:
+    now = datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=days_ago)
+    return now.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# --- Marker parsing -----------------------------------------------------------
+
+
+def test_parse_marker_valid_timestamp(tmp_path: Path) -> None:
+    marker = tmp_path / ".devkit-archived"
+    marker.write_text("2026-04-22T00:00:00Z\n")
+    now = datetime.datetime(2026, 5, 22, 0, 0, 0, tzinfo=datetime.UTC)
+    entry = purge_mod._parse_marker(marker, now)
+    assert entry.marker_error is None
+    assert entry.archived_at is not None
+    assert entry.age_days == 30
+
+
+def test_parse_marker_date_only_accepted(tmp_path: Path) -> None:
+    marker = tmp_path / ".devkit-archived"
+    marker.write_text("2026-04-22\n")
+    now = datetime.datetime(2026, 5, 22, tzinfo=datetime.UTC)
+    entry = purge_mod._parse_marker(marker, now)
+    assert entry.marker_error is None
+
+
+def test_parse_marker_missing(tmp_path: Path) -> None:
+    marker = tmp_path / ".devkit-archived"
+    now = datetime.datetime.now(datetime.UTC)
+    entry = purge_mod._parse_marker(marker, now)
+    assert entry.marker_error is not None
+    assert "missing" in entry.marker_error
+
+
+def test_parse_marker_empty(tmp_path: Path) -> None:
+    marker = tmp_path / ".devkit-archived"
+    marker.write_text("")
+    entry = purge_mod._parse_marker(marker, datetime.datetime.now(datetime.UTC))
+    assert entry.marker_error == "marker file empty"
+
+
+def test_parse_marker_unparseable(tmp_path: Path) -> None:
+    marker = tmp_path / ".devkit-archived"
+    marker.write_text("garbage\n")
+    entry = purge_mod._parse_marker(marker, datetime.datetime.now(datetime.UTC))
+    assert entry.marker_error is not None
+    assert "unparseable" in entry.marker_error
+
+
+def test_parse_marker_future_skew(tmp_path: Path) -> None:
+    marker = tmp_path / ".devkit-archived"
+    future = datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=1)
+    marker.write_text(future.strftime("%Y-%m-%dT%H:%M:%SZ"))
+    entry = purge_mod._parse_marker(marker, datetime.datetime.now(datetime.UTC))
+    assert entry.marker_error is not None
+    assert "future" in entry.marker_error
+
+
+# --- CLI behavior -------------------------------------------------------------
+
+
+def test_purge_dry_run_default_no_deletion(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    old = _make_archived(home, "Old-issue-1", marker_text=_iso(40))
+    young = _make_archived(home, "Young-issue-2", marker_text=_iso(5))
+    monkeypatch.setenv("APP_EMPIRE_WORKTREES_HOME", str(home))
+
+    result = runner.invoke(app, ["purge"])
+    assert result.exit_code == 0, result.output
+    assert old.exists()
+    assert young.exists()
+    assert "would purge Old-issue-1" in result.output
+    assert "would purge Young-issue-2" not in result.output
+
+
+def test_purge_with_yes_deletes_eligible(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    old = _make_archived(home, "Old-issue-1", marker_text=_iso(40))
+    young = _make_archived(home, "Young-issue-2", marker_text=_iso(5))
+    monkeypatch.setenv("APP_EMPIRE_WORKTREES_HOME", str(home))
+
+    result = runner.invoke(app, ["purge", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert not old.exists()
+    assert young.exists()
+
+
+def test_purge_days_override(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    week_old = _make_archived(home, "Week-issue-1", marker_text=_iso(10))
+    monkeypatch.setenv("APP_EMPIRE_WORKTREES_HOME", str(home))
+
+    result = runner.invoke(app, ["purge", "--days", "7", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert not week_old.exists()
+
+
+def test_purge_missing_marker_skipped(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    # Very old dir, but no marker → never touched
+    no_marker = _make_archived(home, "NoMarker-issue-9", marker_text=None)
+    monkeypatch.setenv("APP_EMPIRE_WORKTREES_HOME", str(home))
+
+    result = runner.invoke(app, ["purge", "--days", "0", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert no_marker.exists()
+    assert "SKIP NoMarker-issue-9" in result.output
+
+
+def test_purge_unparseable_marker_skipped(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    bad = _make_archived(home, "Bad-issue-1", marker_text="not a timestamp\n")
+    monkeypatch.setenv("APP_EMPIRE_WORKTREES_HOME", str(home))
+
+    result = runner.invoke(app, ["purge", "--days", "0", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert bad.exists()
+    assert "SKIP Bad-issue-1" in result.output
+
+
+def test_purge_empty_archived_ok(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "_archived").mkdir()
+    monkeypatch.setenv("APP_EMPIRE_WORKTREES_HOME", str(home))
+
+    result = runner.invoke(app, ["purge"])
+    assert result.exit_code == 0, result.output
+    assert "nothing to purge" in result.output.lower()
+
+
+def test_purge_no_archived_dir_ok(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("APP_EMPIRE_WORKTREES_HOME", str(home))
+
+    result = runner.invoke(app, ["purge"])
+    assert result.exit_code == 0, result.output
+    assert "nothing to purge" in result.output.lower()
+
+
+def test_purge_never_touches_active_workspaces(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    # Active workspace sitting at the root — purge must NEVER see it
+    active = home / "Active-issue-100"
+    active.mkdir()
+    (active / "DevKit").mkdir()
+    old = _make_archived(home, "Old-issue-1", marker_text=_iso(40))
+    monkeypatch.setenv("APP_EMPIRE_WORKTREES_HOME", str(home))
+
+    result = runner.invoke(app, ["purge", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert active.exists()
+    assert (active / "DevKit").exists()
+    assert not old.exists()
+
+
+def test_purge_missing_env_exits_16(
+    runner: CliRunner,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("APP_EMPIRE_WORKTREES_HOME", raising=False)
+    result = runner.invoke(app, ["purge"])
+    assert result.exit_code == E_WORKSPACE_MISSING

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,439 @@
+"""Tests for `devkit status`."""
+from __future__ import annotations
+
+import json
+from importlib.resources import as_file, files
+from pathlib import Path
+
+import jsonschema
+import pytest
+from typer.testing import CliRunner
+
+from aidevkit import status as status_mod
+from aidevkit.cli import app
+from aidevkit.util import RunResult
+
+
+@pytest.fixture
+def runner(monkeypatch: pytest.MonkeyPatch) -> CliRunner:
+    monkeypatch.setenv("NO_COLOR", "1")
+    return CliRunner()
+
+
+def _load_schema() -> dict:
+    schema_res = files("aidevkit.schemas") / "status.schema.json"
+    with as_file(schema_res) as path:
+        return json.loads(Path(path).read_text())
+
+
+def _make_workspace(
+    home: Path,
+    repo: str,
+    num: int,
+    *,
+    upstream_root: Path | None = None,
+    extra_repo: tuple[str, Path] | None = None,
+) -> Path:
+    """Create a minimal per-issue workspace tree.
+
+    If `upstream_root` is provided, create a `.git` file in the subdir pointing
+    at `<upstream>/.git/worktrees/<subdir>/`. Otherwise the subdir exists but
+    has no `.git`, simulating a missing worktree.
+    """
+    workspace = home / f"{repo}-issue-{num}"
+    workspace.mkdir()
+    subdir = workspace / repo
+    subdir.mkdir()
+    if upstream_root is not None:
+        gitdir = upstream_root / ".git" / "worktrees" / repo
+        gitdir.mkdir(parents=True, exist_ok=True)
+        (subdir / ".git").write_text(f"gitdir: {gitdir}\n")
+    if extra_repo is not None:
+        name, extra_upstream = extra_repo
+        extra_sub = workspace / name
+        extra_sub.mkdir()
+        extra_gitdir = extra_upstream / ".git" / "worktrees" / name
+        extra_gitdir.mkdir(parents=True, exist_ok=True)
+        (extra_sub / ".git").write_text(f"gitdir: {extra_gitdir}\n")
+    return workspace
+
+
+def _make_upstream(tmp_path: Path, repo: str) -> Path:
+    root = tmp_path / "projects" / repo
+    (root / ".git").mkdir(parents=True)
+    return root
+
+
+# --- Enumeration --------------------------------------------------------------
+
+
+def test_enumerate_skips_archived_and_non_matching(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "_archived").mkdir()
+    (home / "_archived" / "Old-issue-1").mkdir()
+    (home / "DevKit-issue-20").mkdir()
+    (home / "AuthService-issue-2").mkdir()
+    (home / "random-file").write_text("x")
+    (home / "some-other-dir").mkdir()
+
+    found = status_mod._enumerate_workspaces(home.resolve())
+    names = {p.name for p in found}
+    assert names == {"DevKit-issue-20", "AuthService-issue-2"}
+
+
+def test_parse_dir_name_matches_pattern() -> None:
+    assert status_mod._parse_dir_name("DevKit-issue-20") == ("DevKit", 20)
+    assert status_mod._parse_dir_name("App.Empire_LLC-issue-5") == ("App.Empire_LLC", 5)
+    assert status_mod._parse_dir_name("_archived") is None
+    assert status_mod._parse_dir_name("not-an-issue") is None
+
+
+# --- Branch state collection --------------------------------------------------
+
+
+def test_collect_branch_state_reports_clean_tree(
+    tmp_path: Path, subprocess_capture
+) -> None:
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    (worktree / ".git").write_text("gitdir: x")
+    # status --porcelain, rev-parse --abbrev-ref HEAD, rev-list --left-right --count
+    subprocess_capture.queue(RunResult(code=0, stdout="", stderr=""))
+    subprocess_capture.queue(RunResult(code=0, stdout="issue-X-1\n", stderr=""))
+    subprocess_capture.queue(RunResult(code=0, stdout="0\t3\n", stderr=""))
+    bs = status_mod._collect_branch_state(worktree, "issue-X-1")
+    assert bs is not None
+    assert bs.ahead == 3 and bs.behind == 0
+    assert bs.dirty is False and bs.missing is False
+
+
+def test_collect_branch_state_reports_dirty(
+    tmp_path: Path, subprocess_capture
+) -> None:
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    (worktree / ".git").write_text("gitdir: x")
+    subprocess_capture.queue(RunResult(code=0, stdout=" M file\n", stderr=""))
+    subprocess_capture.queue(RunResult(code=0, stdout="issue-X-1\n", stderr=""))
+    subprocess_capture.queue(RunResult(code=0, stdout="2\t1\n", stderr=""))
+    bs = status_mod._collect_branch_state(worktree, "issue-X-1")
+    assert bs is not None
+    assert bs.dirty is True
+    assert bs.behind == 2 and bs.ahead == 1
+
+
+def test_collect_branch_state_missing_upstream(
+    tmp_path: Path, subprocess_capture
+) -> None:
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    (worktree / ".git").write_text("gitdir: x")
+    subprocess_capture.queue(RunResult(code=0, stdout="", stderr=""))
+    subprocess_capture.queue(RunResult(code=0, stdout="issue-X-1\n", stderr=""))
+    subprocess_capture.queue(RunResult(code=1, stdout="", stderr="unknown ref"))
+    bs = status_mod._collect_branch_state(worktree, "issue-X-1")
+    assert bs is not None
+    assert bs.missing is True
+
+
+def test_collect_branch_state_returns_none_when_no_git(tmp_path: Path) -> None:
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    # no .git file — looks like external deletion
+    bs = status_mod._collect_branch_state(worktree, "issue-X-1")
+    assert bs is None
+
+
+# --- Archivable derivation ----------------------------------------------------
+
+
+def test_derive_archivable_requires_closed_issue() -> None:
+    from aidevkit._prs import PR
+    ws = status_mod.Workspace(
+        dir_name="X-issue-1",
+        issue=status_mod.Issue(
+            owner_repo="o/X", number=1, title="", state="open"
+        ),
+        branch="issue-X-1",
+        archivable=False,
+        repos=[
+            status_mod.RepoStatus(
+                name="X",
+                worktree_present=True,
+                branch_state=status_mod.BranchState(0, 0, False, False),
+                prs=[PR(number=1, state="merged", url="https://x")],
+            )
+        ],
+    )
+    assert status_mod._derive_archivable(ws) is False
+
+
+def test_derive_archivable_requires_merged_pr_per_repo() -> None:
+    from aidevkit._prs import PR
+    ws = status_mod.Workspace(
+        dir_name="X-issue-1",
+        issue=status_mod.Issue(
+            owner_repo="o/X", number=1, title="", state="closed"
+        ),
+        branch="issue-X-1",
+        archivable=False,
+        repos=[
+            status_mod.RepoStatus(
+                name="X",
+                worktree_present=True,
+                branch_state=status_mod.BranchState(0, 0, False, False),
+                prs=[PR(number=1, state="merged", url="https://x")],
+            ),
+            status_mod.RepoStatus(
+                name="Y",
+                worktree_present=True,
+                branch_state=status_mod.BranchState(0, 0, False, False),
+                prs=[PR(number=2, state="open", url="https://y")],
+            ),
+        ],
+    )
+    assert status_mod._derive_archivable(ws) is False
+
+
+def test_derive_archivable_true_when_closed_and_all_merged() -> None:
+    from aidevkit._prs import PR
+    ws = status_mod.Workspace(
+        dir_name="X-issue-1",
+        issue=status_mod.Issue(
+            owner_repo="o/X", number=1, title="", state="closed"
+        ),
+        branch="issue-X-1",
+        archivable=False,
+        repos=[
+            status_mod.RepoStatus(
+                name="X",
+                worktree_present=True,
+                branch_state=status_mod.BranchState(0, 0, False, False),
+                prs=[PR(number=1, state="merged", url="https://x")],
+            )
+        ],
+    )
+    assert status_mod._derive_archivable(ws) is True
+
+
+def test_derive_archivable_false_without_repos() -> None:
+    ws = status_mod.Workspace(
+        dir_name="X-issue-1",
+        issue=status_mod.Issue(
+            owner_repo="o/X", number=1, title="", state="closed"
+        ),
+        branch="issue-X-1",
+        archivable=False,
+        repos=[],
+    )
+    assert status_mod._derive_archivable(ws) is False
+
+
+# --- End-to-end via CLI -------------------------------------------------------
+
+
+def _status_shell_factory(
+    *,
+    issue_state: str = "OPEN",
+    issue_title: str = "Test issue",
+    pr_state: str = "MERGED",
+    git_ahead: int = 0,
+    git_behind: int = 0,
+    git_dirty: bool = False,
+    gh_fails: bool = False,
+):
+    """Build a dispatching shell fake.
+
+    Covers: `git remote get-url origin`, `git status --porcelain`,
+    `git rev-parse --abbrev-ref HEAD`, `git rev-list --left-right --count`,
+    `gh issue view`, `gh pr list`.
+    """
+    def shell(cmd: list[str], **_: object) -> RunResult:
+        if cmd[:3] == ["git", "remote", "get-url"]:
+            return RunResult(
+                code=0,
+                stdout="https://github.com/Owner/Repo.git\n",
+                stderr="",
+            )
+        if cmd[:2] == ["git", "status"]:
+            return RunResult(
+                code=0, stdout=" M file\n" if git_dirty else "", stderr=""
+            )
+        if cmd[:2] == ["git", "rev-parse"]:
+            return RunResult(code=0, stdout="issue-Repo-1\n", stderr="")
+        if cmd[:2] == ["git", "rev-list"]:
+            return RunResult(
+                code=0, stdout=f"{git_behind}\t{git_ahead}\n", stderr=""
+            )
+        if cmd[:3] == ["gh", "issue", "view"]:
+            if gh_fails:
+                return RunResult(code=1, stdout="", stderr="network")
+            return RunResult(
+                code=0,
+                stdout=json.dumps({"state": issue_state, "title": issue_title}),
+                stderr="",
+            )
+        if cmd[:3] == ["gh", "pr", "list"]:
+            if gh_fails:
+                return RunResult(code=1, stdout="", stderr="network")
+            return RunResult(
+                code=0,
+                stdout=json.dumps(
+                    [{"number": 5, "state": pr_state, "url": "https://x/5"}]
+                ),
+                stderr="",
+            )
+        return RunResult(code=0, stdout="", stderr="")
+    return shell
+
+
+def test_status_multi_workspace_json_validates_against_schema(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    upstream_a = _make_upstream(tmp_path, "Repo")
+    upstream_b = _make_upstream(tmp_path, "Other")
+    _make_workspace(home, "Repo", 1, upstream_root=upstream_a)
+    ws2 = home / "Other-issue-2"
+    ws2.mkdir()
+    sub2 = ws2 / "Other"
+    sub2.mkdir()
+    gitdir2 = upstream_b / ".git" / "worktrees" / "Other"
+    gitdir2.mkdir(parents=True)
+    (sub2 / ".git").write_text(f"gitdir: {gitdir2}\n")
+
+    monkeypatch.setenv("APP_EMPIRE_WORKTREES_HOME", str(home))
+    monkeypatch.setattr(
+        "aidevkit.util.run", _status_shell_factory(issue_state="CLOSED")
+    )
+
+    result = runner.invoke(app, ["status", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    jsonschema.validate(payload, _load_schema())
+    assert payload["version"] == 1
+    names = {w["dir_name"] for w in payload["workspaces"]}
+    assert names == {"Repo-issue-1", "Other-issue-2"}
+
+
+def test_status_missing_worktree_reported_without_crash(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    # Workspace exists but no `.git` inside the repo subdir — simulates external deletion
+    workspace = home / "Repo-issue-1"
+    workspace.mkdir()
+    (workspace / "Repo").mkdir()  # no .git file
+
+    monkeypatch.setenv("APP_EMPIRE_WORKTREES_HOME", str(home))
+    monkeypatch.setattr(
+        "aidevkit.util.run", _status_shell_factory(issue_state="OPEN")
+    )
+
+    result = runner.invoke(app, ["status", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    # Workspace appears even though the subdir has no .git — and has zero repos
+    # discovered (not a crash).
+    workspaces = {w["dir_name"]: w for w in payload["workspaces"]}
+    assert "Repo-issue-1" in workspaces
+    assert workspaces["Repo-issue-1"]["repos"] == []
+
+
+def test_status_archived_excluded(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    upstream = _make_upstream(tmp_path, "Repo")
+    _make_workspace(home, "Repo", 1, upstream_root=upstream)
+    archived = home / "_archived"
+    archived.mkdir()
+    (archived / "Repo-issue-99").mkdir()
+
+    monkeypatch.setenv("APP_EMPIRE_WORKTREES_HOME", str(home))
+    monkeypatch.setattr("aidevkit.util.run", _status_shell_factory())
+
+    result = runner.invoke(app, ["status", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    names = {w["dir_name"] for w in payload["workspaces"]}
+    assert names == {"Repo-issue-1"}
+
+
+def test_status_gh_unreachable_sets_unknown(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    upstream = _make_upstream(tmp_path, "Repo")
+    _make_workspace(home, "Repo", 1, upstream_root=upstream)
+
+    monkeypatch.setenv("APP_EMPIRE_WORKTREES_HOME", str(home))
+    monkeypatch.setattr("aidevkit.util.run", _status_shell_factory(gh_fails=True))
+
+    result = runner.invoke(app, ["status", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    ws = payload["workspaces"][0]
+    assert ws["issue"]["state"] == "unknown"
+    assert ws["archivable"] is False
+
+
+def test_status_text_output_shows_archivable_tag(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    upstream = _make_upstream(tmp_path, "Repo")
+    _make_workspace(home, "Repo", 1, upstream_root=upstream)
+
+    monkeypatch.setenv("APP_EMPIRE_WORKTREES_HOME", str(home))
+    monkeypatch.setattr(
+        "aidevkit.util.run",
+        _status_shell_factory(issue_state="CLOSED", pr_state="MERGED"),
+    )
+
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0, result.output
+    assert "Repo-issue-1" in result.output
+    assert "archivable" in result.output
+
+
+def test_status_no_workspaces_is_not_an_error(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("APP_EMPIRE_WORKTREES_HOME", str(home))
+    monkeypatch.setattr("aidevkit.util.run", _status_shell_factory())
+
+    result = runner.invoke(app, ["status", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload == {"version": 1, "workspaces": []}
+
+
+def test_status_missing_home_env_exits_16(
+    runner: CliRunner,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("APP_EMPIRE_WORKTREES_HOME", raising=False)
+    monkeypatch.setattr("aidevkit.util.run", _status_shell_factory())
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 16

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -1,0 +1,137 @@
+"""Tests for `devkit uninstall`."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from aidevkit import uninstall as uninstall_mod
+from aidevkit.cli import app
+from aidevkit.util import E_INSTALL_NOT_UV_TOOL, RunResult
+
+
+@pytest.fixture
+def runner(monkeypatch: pytest.MonkeyPatch) -> CliRunner:
+    monkeypatch.setenv("NO_COLOR", "1")
+    return CliRunner()
+
+
+def _make_fake_commands_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[Path, Path]:
+    """Populate a fake home's `.claude/commands/` with a mix of relevant/irrelevant links."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr("pathlib.Path.home", staticmethod(lambda: home))
+
+    cmd_dir = home / ".claude" / "commands"
+    cmd_dir.mkdir(parents=True)
+
+    # Fake aidevkit install tree
+    aidevkit_install = tmp_path / "install" / "aidevkit"
+    (aidevkit_install / "commands").mkdir(parents=True)
+    archive_md = aidevkit_install / "commands" / "devkit.archive.md"
+    archive_md.write_text("archive")
+    status_md = aidevkit_install / "commands" / "devkit.status.md"
+    status_md.write_text("status")
+
+    # Legitimate DevKit symlinks (matches /aidevkit/commands/ substring)
+    (cmd_dir / "devkit.archive.md").symlink_to(archive_md)
+    (cmd_dir / "devkit.status.md").symlink_to(status_md)
+
+    # Unrelated symlink — must not be touched
+    other = tmp_path / "other.md"
+    other.write_text("other")
+    (cmd_dir / "user.md").symlink_to(other)
+
+    # Regular file — must not be touched
+    (cmd_dir / "userfile.md").write_text("mine")
+
+    return cmd_dir, aidevkit_install
+
+
+def test_uninstall_not_uv_tool_exits_26(
+    runner: CliRunner, subprocess_capture
+) -> None:
+    # detect_install_info: uv tool list returns nothing; pip show fails → unknown
+    subprocess_capture.queue(RunResult(code=0, stdout="", stderr=""))
+    subprocess_capture.queue(RunResult(code=1, stdout="", stderr="not found"))
+    result = runner.invoke(app, ["uninstall"])
+    assert result.exit_code == E_INSTALL_NOT_UV_TOOL
+
+
+def test_uninstall_removes_symlinks_and_ignores_others(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cmd_dir, _install = _make_fake_commands_dir(tmp_path, monkeypatch)
+
+    def shell(cmd: list[str], **_: object) -> RunResult:
+        if cmd[:3] == ["uv", "tool", "list"]:
+            return RunResult(code=0, stdout="aidevkit v0.3.0\n", stderr="")
+        if cmd[:3] == ["uv", "tool", "uninstall"]:
+            return RunResult(code=0, stdout="", stderr="")
+        return RunResult(code=0, stdout="", stderr="")
+
+    monkeypatch.setattr("aidevkit.util.run", shell)
+    result = runner.invoke(app, ["uninstall"])
+    assert result.exit_code == 0, result.output
+    assert not (cmd_dir / "devkit.archive.md").exists()
+    assert not (cmd_dir / "devkit.status.md").exists()
+    # Unrelated symlink and regular file preserved
+    assert (cmd_dir / "user.md").is_symlink()
+    assert (cmd_dir / "userfile.md").is_file()
+
+
+def test_uninstall_idempotent_already_gone(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cmd_dir, _install = _make_fake_commands_dir(tmp_path, monkeypatch)
+    # Remove links first to simulate already-uninstalled state
+    (cmd_dir / "devkit.archive.md").unlink()
+    (cmd_dir / "devkit.status.md").unlink()
+
+    def shell(cmd: list[str], **_: object) -> RunResult:
+        if cmd[:3] == ["uv", "tool", "list"]:
+            return RunResult(code=0, stdout="aidevkit v0.3.0\n", stderr="")
+        if cmd[:3] == ["uv", "tool", "uninstall"]:
+            return RunResult(code=1, stdout="", stderr="aidevkit is not installed")
+        return RunResult(code=0, stdout="", stderr="")
+
+    monkeypatch.setattr("aidevkit.util.run", shell)
+    result = runner.invoke(app, ["uninstall"])
+    assert result.exit_code == 0, result.output
+
+
+def test_uninstall_is_non_interactive(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cmd_dir, _install = _make_fake_commands_dir(tmp_path, monkeypatch)
+
+    def shell(cmd: list[str], **_: object) -> RunResult:
+        if cmd[:3] == ["uv", "tool", "list"]:
+            return RunResult(code=0, stdout="aidevkit v0.3.0\n", stderr="")
+        if cmd[:3] == ["uv", "tool", "uninstall"]:
+            return RunResult(code=0, stdout="", stderr="")
+        return RunResult(code=0, stdout="", stderr="")
+
+    monkeypatch.setattr("aidevkit.util.run", shell)
+    # No stdin provided — command must still succeed without prompting.
+    result = runner.invoke(app, ["uninstall"], input="")
+    assert result.exit_code == 0, result.output
+
+
+def test_devkit_symlinks_helper(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cmd_dir, _install = _make_fake_commands_dir(tmp_path, monkeypatch)
+    found = uninstall_mod._devkit_symlinks(cmd_dir)
+    names = {p.name for p in found}
+    assert names == {"devkit.archive.md", "devkit.status.md"}

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,98 @@
+"""Tests for `devkit update`."""
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from aidevkit.cli import app
+from aidevkit.util import E_DEP_MISSING, E_INSTALL_NOT_UV_TOOL, RunResult
+
+
+@pytest.fixture
+def runner(monkeypatch: pytest.MonkeyPatch) -> CliRunner:
+    monkeypatch.setenv("NO_COLOR", "1")
+    return CliRunner()
+
+
+def test_update_not_manageable_exits_26(
+    runner: CliRunner, subprocess_capture
+) -> None:
+    subprocess_capture.queue(RunResult(code=0, stdout="", stderr=""))
+    subprocess_capture.queue(RunResult(code=1, stdout="", stderr="not found"))
+    result = runner.invoke(app, ["update"])
+    assert result.exit_code == E_INSTALL_NOT_UV_TOOL
+
+
+def test_update_upgrade_then_doctor_success(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    call_counts: dict[str, int] = {"uv_tool_list": 0}
+
+    def shell(cmd: list[str], **_: object) -> RunResult:
+        if cmd[:3] == ["uv", "tool", "list"]:
+            call_counts["uv_tool_list"] += 1
+            # first call = before, second = after — pretend upgrade bumped to 0.3.1
+            if call_counts["uv_tool_list"] == 1:
+                return RunResult(code=0, stdout="aidevkit v0.3.0\n", stderr="")
+            return RunResult(code=0, stdout="aidevkit v0.3.1\n", stderr="")
+        if cmd[:3] == ["uv", "tool", "upgrade"]:
+            return RunResult(code=0, stdout="Updated aidevkit v0.3.1\n", stderr="")
+        # Doctor's git/gh checks — pretend all binaries/env present
+        if cmd == ["gh", "auth", "status"]:
+            return RunResult(
+                code=0,
+                stdout="",
+                stderr="Logged in to github.com as ci\n",
+            )
+        return RunResult(code=0, stdout="", stderr="")
+
+    monkeypatch.setattr("aidevkit.util.run", shell)
+    # Doctor checks binaries via shutil.which and env vars
+    monkeypatch.setattr("aidevkit.doctor.shutil.which", lambda n: "/bin/" + n)
+    monkeypatch.setenv("APP_EMPIRE_PROJECTS", "/tmp")
+    monkeypatch.setenv("APP_EMPIRE_WORKTREES_HOME", "/tmp")
+
+    result = runner.invoke(app, ["update"])
+    assert result.exit_code == 0, result.output
+    assert "0.3.0 → 0.3.1" in result.output
+
+
+def test_update_doctor_failure_propagates(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Per FR-SELF-005: doctor failure must surface as non-zero exit; no rollback."""
+    def shell(cmd: list[str], **_: object) -> RunResult:
+        if cmd[:3] == ["uv", "tool", "list"]:
+            return RunResult(code=0, stdout="aidevkit v0.3.0\n", stderr="")
+        if cmd[:3] == ["uv", "tool", "upgrade"]:
+            return RunResult(code=0, stdout="", stderr="")
+        if cmd == ["gh", "auth", "status"]:
+            return RunResult(code=1, stdout="", stderr="not authenticated")
+        return RunResult(code=0, stdout="", stderr="")
+
+    monkeypatch.setattr("aidevkit.util.run", shell)
+    # Missing a required binary → doctor fails with E_DEP_MISSING
+    monkeypatch.setattr(
+        "aidevkit.doctor.shutil.which",
+        lambda n: None if n == "jq" else "/bin/" + n,
+    )
+    monkeypatch.setenv("APP_EMPIRE_PROJECTS", "/tmp")
+    monkeypatch.setenv("APP_EMPIRE_WORKTREES_HOME", "/tmp")
+
+    result = runner.invoke(app, ["update"])
+    assert result.exit_code == E_DEP_MISSING
+
+
+def test_update_upgrade_failure_propagates(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def shell(cmd: list[str], **_: object) -> RunResult:
+        if cmd[:3] == ["uv", "tool", "list"]:
+            return RunResult(code=0, stdout="aidevkit v0.3.0\n", stderr="")
+        if cmd[:3] == ["uv", "tool", "upgrade"]:
+            return RunResult(code=1, stdout="", stderr="network unreachable")
+        return RunResult(code=0, stdout="", stderr="")
+
+    monkeypatch.setattr("aidevkit.util.run", shell)
+    result = runner.invoke(app, ["update"])
+    assert result.exit_code == 1

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "aidevkit"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
## Summary

Adds six new DevKit subcommands and the marker-file extension that makes them work as a lifecycle:

- `devkit status [--json]` — one command, every active workspace; issue state, per-repo branch state, PRs, `archivable` flag (closes #9)
- `devkit add-repo <name>` — mid-session sibling worktree; CWD-inferred workspace/branch/source (closes #7)
- `devkit purge [--days N] [--yes]` — age-gated deletion of `_archived/` dirs; dry-run default; skips dirs without a valid `.devkit-archived` marker (closes #10)
- `devkit uninstall` / `devkit update` / `devkit check-update` — self-management via `uv tool` (closes #20)
- `devkit archive` now drops `.devkit-archived` (ISO 8601 UTC timestamp) inside the archived dir — required so `purge` can age-gate safely.

See [spec](https://github.com/App-Empire-LLC/DevKit/issues/20#issuecomment-...) for the full design — the spec is posted to #20 by `devkit archive` at merge time.

### Design highlights

- **Shared `_prs.py`** — `archive` and `status` use the same PR-merge signal; they can't disagree about whether a workspace is archivable.
- **Thread-pooled status (`max_workers=8`)** — stays under SC-001's 5s budget for 15-workspace × 2-repo scans.
- **`.devkit-archived` marker** — single-line ISO 8601 UTC; missing/unparseable/future markers cause `purge` to skip, never delete.
- **Install-method detection** — `_install.detect_install_info` distinguishes `uv-tool` (manageable) from `pip` / `source` / `unknown`; non-`uv-tool` installs exit 26 with guidance rather than a cryptic `uv` error.
- **No rollback on `update` doctor failure** (FR-SELF-005) — the upgrade succeeded; doctor's findings surface verbatim and the command exits with doctor's code.
- **New error codes**: 24 `E_NOT_IN_PER_ISSUE_WORKSPACE`, 26 `E_INSTALL_NOT_UV_TOOL`, 27 `E_CHECK_UPDATE_INDEX_UNAVAILABLE`.

### Test coverage

195 tests (up from 122 baseline): unit tests for every new module (`_prs`, `status`, `add_repo`, `purge`, `_install`, `uninstall`, `update`, `check_update`) plus two new real-git integration tests (`test_add_repo_end_to_end.py`, `test_purge_end_to_end.py`) alongside the updated `test_archive_end_to_end.py` marker assertion.

### Version

Feature-size bump: `aidevkit` 0.2.0 → 0.3.0.

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run pytest -q` — 195 passed
- [ ] Manual smoke: install 0.3.0 via `uv tool install --from . --reinstall aidevkit`, run `devkit --help`, `devkit status`, `devkit check-update`
- [ ] Archive-dogfood: run `devkit archive App-Empire-LLC/DevKit#20` after merge to post spec + exercise the new marker path
- [ ] Purge-dogfood: after marker backfill, run `devkit purge --days 0` (dry) then `--yes` on a throwaway archived dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)