### PR TITLE
review-issue: pre-SpecKit issue quality gate command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Companion tooling for GitHub Spec-Kit and the App Empire per-issue worktree work
 
 - `src/aidevkit/` — the Python package
   - `cli.py` — Typer app + subcommand wiring
-  - `bootstrap.py` / `doctor.py` / `setup.py` / `sync.py` — one module per subcommand
+  - `bootstrap.py` / `doctor.py` / `setup.py` / `sync.py` / `review_issue.py` — one module per subcommand
   - `util.py` — exit-code constants, Rich consoles, `log`/`info`/`die`, subprocess helpers (`run`/`git`/`gh`)
   - `commands/` — bundled Claude Code slash-command markdown, symlinked into `~/.claude/commands/` by `devkit setup`
   - `schemas/` — JSON Schemas shipped as package resources (load via `importlib.resources.files("aidevkit.schemas")`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,11 @@ dependencies = [
     "typer>=0.12",
     "rich>=13",
     "pyyaml>=6.0",
+    # jsonschema validates LLM-produced findings input at runtime in the
+    # `review-issue post` command (DevKit#17 — see specs/001-review-issue/
+    # plan.md). The plan originally listed it as test-only; runtime validation
+    # of the slash-command handoff promoted it to a primary dep.
+    "jsonschema>=4",
 ]
 
 [project.optional-dependencies]

--- a/src/aidevkit/cli.py
+++ b/src/aidevkit/cli.py
@@ -13,6 +13,7 @@ from . import config as _config
 from . import doctor as _doctor
 from . import preflight as _preflight
 from . import purge as _purge
+from . import review_issue as _review_issue
 from . import setup as _setup
 from . import status as _status
 from . import sync as _sync
@@ -234,3 +235,93 @@ def check_update(
 def version() -> None:
     info(f"aidevkit {__version__}")
     raise typer.Exit(code=0)
+
+
+# review-issue: pre-SpecKit issue quality gate (DevKit#17). Two subcommands
+# (`inspect` and `post`) compose into the `/devkit.review-issue` slash command.
+review_issue_app = typer.Typer(
+    name="review-issue",
+    help="Review a GitHub issue against the App Empire product-request standard.",
+    no_args_is_help=True,
+)
+app.add_typer(review_issue_app, name="review-issue")
+
+
+@review_issue_app.command("inspect", help="Fetch issue + prior runs, emit JSON for the LLM.")
+def review_issue_inspect(
+    issue_arg: str = typer.Argument(
+        ...,
+        metavar="OWNER/REPO#N",
+        help="GitHub issue reference, e.g. 'App-Empire-LLC/DevKit#17'.",
+    ),
+    reviewer_id: str = typer.Option(
+        None,
+        "--reviewer-id",
+        help="Override reviewer-id (default: 'claude' or value from .devkit/config.yaml).",
+    ),
+) -> None:
+    issue_arg = _expand_bare_ref(issue_arg)
+    code = _review_issue.cmd_review_issue_inspect(
+        ref=issue_arg, reviewer_id=reviewer_id,
+    )
+    raise typer.Exit(code=code)
+
+
+@review_issue_app.command(
+    "post",
+    help="Validate findings JSON on stdin and post the consolidated review comment.",
+)
+def review_issue_post(
+    issue_arg: str = typer.Argument(
+        ...,
+        metavar="OWNER/REPO#N",
+        help="GitHub issue reference, e.g. 'App-Empire-LLC/DevKit#17'.",
+    ),
+    findings_stdin: bool = typer.Option(
+        False,
+        "--findings-stdin",
+        help="Required marker indicating findings JSON is being read from stdin.",
+    ),
+    reviewer_id: str = typer.Option(
+        None,
+        "--reviewer-id",
+        help=(
+            "Override reviewer-id (must match the value used in the "
+            "corresponding `inspect` call)."
+        ),
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Render the consolidated comment to stdout; do NOT post.",
+    ),
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit the full JSON envelope to stdout.",
+    ),
+    verbose: bool = typer.Option(
+        False, "--verbose", help="Include nit-level findings as full rows in the comment table.",
+    ),
+    min_severity: str = typer.Option(
+        "warning",
+        "--min-severity",
+        help=(
+            "One of blocker/warning/nit. If all findings are below the threshold, "
+            "the comment is NOT posted."
+        ),
+    ),
+) -> None:
+    issue_arg = _expand_bare_ref(issue_arg)
+    if not findings_stdin:
+        from .util import die as _die
+        _die(
+            "`--findings-stdin` is required (this reserves space for a future "
+            "`--findings <path>` form). Pipe a findings JSON document into stdin.",
+            code=2,
+        )
+    code = _review_issue.cmd_review_issue_post(
+        ref=issue_arg,
+        reviewer_id=reviewer_id,
+        dry_run=dry_run,
+        json_output=json_output,
+        verbose=verbose,
+        min_severity=min_severity,
+    )
+    raise typer.Exit(code=code)

--- a/src/aidevkit/commands/devkit.review-issue.md
+++ b/src/aidevkit/commands/devkit.review-issue.md
@@ -1,0 +1,199 @@
+---
+description: Review a GitHub issue against the App Empire product-request standard before SpecKit handoff
+---
+
+# /devkit.review-issue
+
+Pre-SpecKit quality gate. Reviews a GitHub issue against `appire_docs/docs/engineering/standards/product_requests.md` and posts a single consolidated review comment with a `READY` / `READY_WITH_WARNINGS` / `BLOCKED` gate.
+
+This command is operator-explicit only. There is no auto-trigger on issue events or comment activity.
+
+## Usage
+
+The user gives you an issue reference. Either form is accepted:
+
+- Fully qualified: `App-Empire-LLC/DevKit#42`
+- Bare (expanded via the `org` config field): `DevKit#42`
+
+```bash
+/devkit.review-issue App-Empire-LLC/DevKit#42
+/devkit.review-issue DevKit#42
+/devkit.review-issue DevKit#42 --dry-run
+/devkit.review-issue DevKit#42 --json
+/devkit.review-issue DevKit#42 --verbose
+/devkit.review-issue DevKit#42 --min-severity warning
+```
+
+If the user gives you a bare number with no repo (e.g. `#42`), ask them to confirm the `owner/repo` before running.
+
+## What to do
+
+Orchestrate two sub-invocations of `devkit review-issue`:
+
+### Step 1 — inspect
+
+Run:
+
+```bash
+devkit review-issue inspect <ref> [--reviewer-id <id>]
+```
+
+Parse the JSON envelope it prints. You'll use `issue.ref`, `issue.url`, the next `run.n_next`, and any `prior_runs` to ground your review.
+
+### Step 2 — read the canon
+
+Read `appire_docs/docs/engineering/standards/product_requests.md`. It's the source of truth for everything below; do not rely on training data.
+
+### Step 3 — apply the detectors
+
+Build a findings list classified by category and severity. Each finding is one of:
+
+**Review Checklist (9 questions from `product_requests.md`)** — for each, emit a `completeness` finding when the answer is "no" or "unclear":
+
+1. Does this issue describe what needs to be true?
+2. Did the author accidentally describe how to build it?
+3. Are implementation notes clearly separated from acceptance criteria?
+4. Would `clarify` or `analyze` complain that the spec contains technical implementation details?
+5. Are the acceptance criteria observable and judgeable?
+6. Is the out-of-scope section strong enough to prevent scope creep?
+7. Could Claude Code implement the wrong thing because the issue is too vague?
+8. Could Claude Code over-constrain the spec because the issue is too specific?
+9. Does the issue stand alone without relying on chat history?
+
+**Definition of Done for Issue Authoring (8 items from `product_requests.md`)** — for each, emit a `completeness` finding when the item isn't satisfied:
+
+1. Actor and desired outcome are clear.
+2. Acceptance criteria describe observable outcomes.
+3. Technical details are limited to true constraints.
+4. Implementation advice is separated from requirements.
+5. Out-of-scope boundaries are explicit.
+6. The issue can be understood without reading prior chat history.
+7. SpecKit can generate a spec without inheriting accidental implementation requirements.
+8. Claude Code has enough context to proceed without guessing product intent.
+
+**Anti-patterns (3, from `product_requests.md`)** — emit one finding per detected instance:
+
+- `requirement-leakage` — implementation choices presented as acceptance criteria (e.g., "Use Ory Kratos for auth").
+- `test-plan-as-ac` — acceptance criteria that name test mechanics rather than expected behavior.
+- `chat-history-dependency` — issue depends on prior chat history for core meaning.
+
+**Negative-wording pass** — for each AC containing words like "without", "does not", "must not", "not require", "no external", "out of scope", "avoid", "prevent", "never", emit a `negative-wording` finding flagged for operator triage.
+
+**Issue-internal entailment pass** — for each negative AC, ask: *Does any positive AC in the same issue describe a behavior whose verification would catch a violation of this negative?*
+
+- If yes → emit a `derived-negative-pair` finding (severity `warning`) with both AC references and three operator dispositions:
+  - `drop` — let SpecKit infer the negative from the positive.
+  - `non-goal` — keep as non-goal documentation only, no separate test.
+  - `risk-control` — escalate to a hardening test (rare; security/cost/data-loss vectors).
+- If no positive counterpart exists → emit only the `negative-wording` finding (no entailment claim).
+
+**Label / project-board hygiene** — emit `label-hygiene` for missing type/project/initiative labels; emit `board-hygiene` (severity `blocker` by default; the harness downgrades to `warning` when no project board exists for the repo) when the issue isn't on a project board with required fields set.
+
+**Explicit exclusions** (do NOT check):
+
+- "Estimates present?" — App Empire does not estimate. The 17 items above are the complete checklist; do not add an estimates-presence check.
+- Anything that requires spec / plan / tasks artifacts (the deeper six-category disposition: functional contract / runtime-startup / arch boundary / non-goal / risk control / derived-negative-from-spec). That belongs to `/speckit.analyze`.
+
+### Step 4 — assign IDs
+
+Number the findings `F01`, `F02`, ... in this order: anti-patterns first, then completeness, then derived-negative pairs, then ambiguity, then nits.
+
+### Step 5 — build the findings JSON
+
+Construct a document conforming to `review-issue-findings.schema.json` (shipped at `aidevkit/schemas/`):
+
+```json
+{
+  "schema_version": "1",
+  "findings": [
+    {
+      "id": "F01",
+      "category": "requirement-leakage",
+      "severity": "blocker",
+      "location": "Acceptance Criteria, item 3",
+      "summary": "AC-3 names a specific framework rather than the desired behavior.",
+      "recommendation": "Reword as observable behavior; move framework choice to Notes / Context.",
+      "evidence": "> AC-3: Use Express for the API."
+    }
+  ]
+}
+```
+
+For `derived-negative-pair` findings, include the required `pair` object with `positive_ref`, `negative_ref`, optional `entailment_explanation`, and exactly three `dispositions`:
+
+```json
+{
+  "id": "F02",
+  "category": "derived-negative-pair",
+  "severity": "warning",
+  "location": "Acceptance Criteria, items 1-2",
+  "summary": "AC-2 (does not require cortex-config) is entailed by AC-1 (loads from env var).",
+  "recommendation": "Drop AC-2, keep as non-goal documentation, or escalate to a risk-control test.",
+  "pair": {
+    "positive_ref": "AC-1: loads config from a single env var",
+    "negative_ref": "AC-2: does not require cortex-config",
+    "entailment_explanation": "Verifying AC-1 verifies AC-2.",
+    "dispositions": [
+      {"choice": "drop", "description": "Let SpecKit infer the negative."},
+      {"choice": "non-goal", "description": "Keep as non-goal documentation only."},
+      {"choice": "risk-control", "description": "Escalate to a hardening test (rare)."}
+    ]
+  }
+}
+```
+
+### Step 6 — pipe to post
+
+Pipe the findings JSON to:
+
+```bash
+devkit review-issue post <ref> --findings-stdin \
+  --reviewer-id <id> \
+  [--dry-run] [--json] [--verbose] [--min-severity <level>]
+```
+
+**Forward all operator-supplied flags verbatim**, and use the SAME `--reviewer-id` value you passed to `inspect` so the run-N counter stays consistent. The harness will validate the findings JSON, compute the gate, render the consolidated comment, and post it (unless suppressed).
+
+## Authoring loop with --dry-run
+
+While iterating on a draft issue, run with `--dry-run`:
+
+```bash
+/devkit.review-issue DevKit#42 --dry-run
+```
+
+The full findings table and gate are printed in the operator's session; nothing is posted. Re-run as the issue is edited until the gate is `READY`.
+
+## --json mode
+
+Run with `--json` to get a machine-readable envelope conforming to `review-issue-output.schema.json`:
+
+```bash
+/devkit.review-issue DevKit#42 --json
+```
+
+Use this mode when feeding downstream automation (e.g., a future "promote to Ready" workflow). Combine with `--dry-run` to get the envelope without posting.
+
+## Posting-mode tuning
+
+- `--verbose` — include nit-level findings as their own rows in the comment table. Without this flag, nits are aggregated into a single row whose Summary names the count and points the operator at `--verbose`.
+- `--min-severity <level>` — `blocker` / `warning` / `nit`. When all findings are below the threshold, the comment is NOT posted (the gate is still computed and shown locally and via `--json`).
+
+## Common exit codes
+
+- **2** `E_USAGE` — bad ref or unknown flag.
+- **13** `E_REPO_NOT_FOUND` — gh says the issue or repo doesn't exist or isn't accessible.
+- **70** `E_CONFIG_INVALID` — `.devkit/config.yaml` `review_issue` block fails schema, or the hardcoded product-request standard path can't be found in this workspace (likely cause: `appire_docs` not checked out as a sibling repo).
+- **74** `E_FINDINGS_INVALID` — the findings JSON failed schema validation; the harness posts no comment.
+- **75** `E_GH_COMMENT_FAILED` — `gh issue comment` returned non-zero; the issue thread is unchanged.
+
+## Notes
+
+- One consolidated comment per run. The slash command never posts per-finding comments.
+- Each comment carries an HTML marker `<!-- devkit-review-issue:<reviewer-id>:run-N -->` on its first line. Re-runs add a new comment with an incremented `run-N`; prior comments are not edited or deleted by the harness.
+- The product-request standard's path is locked at `appire_docs/docs/engineering/standards/product_requests.md` per spec FR-006 (configurability deferred — see `specs/001-review-issue/creep.md` K3).
+- The default gate policy (per spec FR-012):
+  - `BLOCKED` — no summary, no AC section, no observable outcome, all ACs are implementation detail (Requirement Leakage), or issue not on a project board (when the repo has one).
+  - `READY_WITH_WARNINGS` — ambiguity placeholders ("TBD", "we'll figure out"), AC duplication or entailment, broad prohibitions, missing labels, missing parent-epic reference where applicable, negatives needing operator triage.
+  - `READY` — none of the above. Nits may still be present.
+- Run from any directory; the command does not require a per-issue workspace. It does require `appire_docs` to be checked out as a sibling repo so the standard resolves.

--- a/src/aidevkit/config.py
+++ b/src/aidevkit/config.py
@@ -177,10 +177,102 @@ def _load_yaml(path: Path) -> dict[str, Any]:
 
 _ALLOWED_GLOBAL_FIELDS = {
     "version", "org", "workspaces_home", "always_include_repos", "projects_home",
+    "review_issue",
 }
 _ALLOWED_PROJECTS_HOME_FIELDS = {
     "version", "org", "workspaces_home", "always_include_repos",
+    "review_issue",
 }
+
+_REVIEWER_ID_RE = re.compile(r"^[a-z][a-z0-9-]{0,30}$")
+
+
+@dataclass(frozen=True)
+class ReviewIssueConfig:
+    """Optional `review_issue` block from `.devkit/config.yaml`.
+
+    Two fields per spec/research R5 (creep K3/K4 cut the rest):
+    - reviewer_id: identity for run-marker grouping (default "claude")
+    - project_board_required: whether absence of a project board is blocker (default True)
+    """
+
+    reviewer_id: str = "claude"
+    project_board_required: bool = True
+
+
+def _validate_review_issue_block(raw: Any, source: Path) -> ReviewIssueConfig:
+    """Parse and validate the review_issue config block. Returns defaults if raw is None."""
+    if raw is None:
+        return ReviewIssueConfig()
+    if not isinstance(raw, dict):
+        _config_error(
+            "review_issue",
+            source,
+            f"value must be a mapping (got {type(raw).__name__})",
+            "use YAML mapping syntax, e.g.\n    review_issue:\n      reviewer_id: claude",
+        )
+    allowed = {"reviewer_id", "gate"}
+    for key in raw:
+        if key not in allowed:
+            _config_error(
+                f"review_issue.{key}",
+                source,
+                f"unknown field: {key!r}",
+                f"remove the field. Allowed: {sorted(allowed)} "
+                "(see research.md R5 / creep.md K3/K4)",
+            )
+    reviewer_id = raw.get("reviewer_id", "claude")
+    if not isinstance(reviewer_id, str) or not _REVIEWER_ID_RE.match(reviewer_id):
+        _config_error(
+            "review_issue.reviewer_id",
+            source,
+            f"value must match {_REVIEWER_ID_RE.pattern} (got {reviewer_id!r})",
+            "use lowercase letters, digits, and hyphens only — e.g. 'claude' or 'gpt'",
+        )
+    gate = raw.get("gate", {})
+    if not isinstance(gate, dict):
+        _config_error(
+            "review_issue.gate",
+            source,
+            f"value must be a mapping (got {type(gate).__name__})",
+            "use YAML mapping syntax, e.g.\n    review_issue:\n"
+            "      gate:\n        project_board_required: true",
+        )
+    gate_allowed = {"project_board_required"}
+    for key in gate:
+        if key not in gate_allowed:
+            _config_error(
+                f"review_issue.gate.{key}",
+                source,
+                f"unknown field: {key!r}",
+                f"remove the field. Allowed: {sorted(gate_allowed)}",
+            )
+    project_board_required = gate.get("project_board_required", True)
+    if not isinstance(project_board_required, bool):
+        _config_error(
+            "review_issue.gate.project_board_required",
+            source,
+            f"value must be a boolean (got {type(project_board_required).__name__})",
+            "use 'true' or 'false'",
+        )
+    return ReviewIssueConfig(
+        reviewer_id=reviewer_id,
+        project_board_required=project_board_required,
+    )
+
+
+def load_review_issue_config(projects_home: Path) -> ReviewIssueConfig:
+    """Load the optional `review_issue` block from the projects-home config.
+
+    Reads only the projects-home tier (matches `load_merged_config`'s primary
+    source). Returns defaults if the block is absent. Raises `typer.Exit(70)`
+    via `_config_error` on schema failure.
+    """
+    projects_home_config = projects_home / DEVKIT_DIRNAME / CONFIG_FILENAME
+    if not projects_home_config.is_file():
+        return ReviewIssueConfig()
+    data = _load_yaml(projects_home_config)
+    return _validate_review_issue_block(data.get("review_issue"), projects_home_config)
 
 
 def _check_unknown_fields(data: dict[str, Any], allowed: set[str], source: Path) -> None:

--- a/src/aidevkit/review_issue.py
+++ b/src/aidevkit/review_issue.py
@@ -1,0 +1,562 @@
+"""DevKit `review-issue` — pre-SpecKit issue quality gate (DevKit#17).
+
+Two subcommands compose into the `/devkit.review-issue` slash command:
+
+- ``inspect``: fetch the issue + its comment thread, scan for prior run
+  markers, emit a JSON envelope the slash-command markdown (LLM-side)
+  consumes to drive its semantic review.
+- ``post``: validate a findings JSON document supplied on stdin against
+  ``review-issue-findings.schema.json``, compute the gate, render the
+  consolidated review comment, optionally post it via ``gh issue comment``.
+
+The split keeps semantic analysis (anti-pattern detection, AC entailment,
+ambiguity, derived-negative pairs) in the slash-command markdown where the
+LLM does that work naturally, and keeps the Python harness deterministic +
+hermetic. All ``gh`` calls flow through ``aidevkit.util.run`` per the
+project-wide hermeticity rule.
+
+See ``specs/001-review-issue/`` for the full design (spec, plan, research,
+data-model, contracts, tasks, creep notes).
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import tempfile
+from dataclasses import dataclass
+from importlib.resources import files as _resource_files
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import typer
+
+from . import __version__
+from .config import (
+    ReviewIssueConfig,
+    load_review_issue_config,
+    resolve_projects_home,
+)
+from .util import (
+    E_CONFIG_INVALID,
+    E_FINDINGS_INVALID,
+    E_GH_COMMENT_FAILED,
+    E_REPO_NOT_FOUND,
+    die,
+    gh,
+    info,
+    log,
+    out,
+)
+
+# Regex for parsing prior-run markers on the issue's comment thread.
+# Anchored to start-of-line so an HTML comment elsewhere in a body cannot be
+# confused with a run marker.
+_RUN_MARKER_RE = re.compile(
+    r"^<!--\s*devkit-review-issue:([a-z][a-z0-9-]{0,30}):run-(\d+)\s*-->",
+    re.MULTILINE,
+)
+
+# Issue-ref parser: matches `owner/repo#N`. Mirrors bootstrap.py's _ISSUE_REF.
+_ISSUE_REF_RE = re.compile(r"^([^/\s#]+)/([^/\s#]+)#(\d+)$")
+
+_SEVERITY_ORDER = {"blocker": 3, "warning": 2, "nit": 1}
+_ANTIPATTERN_CATEGORIES = frozenset(
+    {"requirement-leakage", "test-plan-as-ac", "chat-history-dependency"}
+)
+
+
+@dataclass(frozen=True)
+class ReviewConfig:
+    """Resolved per-invocation review configuration.
+
+    Composes the persisted ``ReviewIssueConfig`` with per-call overrides and
+    runtime context (e.g., whether the repo has a project board configured).
+    """
+
+    reviewer_id: str
+    project_board_required: bool
+    # True when gh confirmed a project board exists for the repo. Drives the
+    # board-degradation rule in ``_compute_gate``: a "not on board" finding is
+    # downgraded blocker→warning when no board exists.
+    project_board_available_for_repo: bool = True
+
+
+# --------------------------------------------------------------------------- #
+# Schema loading (cached at module level so tests don't reload on every call)
+# --------------------------------------------------------------------------- #
+
+
+def _load_schema(name: str) -> dict[str, Any]:
+    raw = _resource_files("aidevkit.schemas").joinpath(name).read_text()
+    return json.loads(raw)
+
+
+_FINDINGS_SCHEMA = _load_schema("review-issue-findings.schema.json")
+_OUTPUT_SCHEMA = _load_schema("review-issue-output.schema.json")
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _resolve_review_config(reviewer_id_override: str | None) -> ReviewConfig:
+    """Resolve the review config from .devkit/config.yaml + CLI override.
+
+    Priority for reviewer_id (research R4): CLI flag > config > default "claude".
+    Falls back to defaults when projects-home isn't resolvable (e.g., running
+    outside any DevKit workspace).
+    """
+    persisted = ReviewIssueConfig()
+    try:
+        projects_home = resolve_projects_home()
+        persisted = load_review_issue_config(projects_home)
+    except typer.Exit:
+        # No projects-home config — defaults apply. The standard-path resolver
+        # (T010) will surface a clearer error if the operator is genuinely in
+        # the wrong context.
+        pass
+    return ReviewConfig(
+        reviewer_id=reviewer_id_override or persisted.reviewer_id,
+        project_board_required=persisted.project_board_required,
+    )
+
+
+def _resolve_product_request_standard_path() -> Path:
+    """Locate the product-request standard.
+
+    Per research R10 / creep K3, the path is hardcoded — no config field.
+    Search order:
+      1. ``$DEVKIT_REVIEW_ISSUE_STANDARD_PATH`` env var (test hook only).
+      2. ``<cwd>/appire_docs/...`` — sibling repo in the workspace.
+      3. ``<cwd>/../appire_docs/...`` — sibling at the workspace root.
+    Fails with E_CONFIG_INVALID if none resolve.
+    """
+    rel = "appire_docs/docs/engineering/standards/product_requests.md"
+    env_override = os.environ.get("DEVKIT_REVIEW_ISSUE_STANDARD_PATH")
+    if env_override:
+        candidate = Path(env_override)
+        if candidate.is_file():
+            return candidate.resolve()
+    cwd = Path.cwd()
+    for base in (cwd, cwd.parent):
+        candidate = base / rel
+        if candidate.is_file():
+            return candidate.resolve()
+    die(
+        f"product-request standard not found.\n"
+        f"  Expected: <workspace>/{rel}\n"
+        f"  Searched: {cwd / rel}\n"
+        f"           {cwd.parent / rel}\n"
+        f"  Likely cause: appire_docs is not checked out as a sibling repo in this workspace.\n"
+        f"  Fix: clone or worktree appire_docs alongside the repo you're reviewing from.",
+        code=E_CONFIG_INVALID,
+    )
+    raise AssertionError("die() should have exited")  # pragma: no cover
+
+
+def _parse_ref(ref: str) -> tuple[str, str, int]:
+    """Split `owner/repo#N` → (owner, repo, num). gh CLI doesn't accept the
+    combined form for `issue view`, so callers split and pass `--repo` + num.
+    """
+    m = _ISSUE_REF_RE.match(ref)
+    if not m:
+        die(
+            f"issue ref must be in form 'owner/repo#N' (got: {ref!r})",
+            code=2,  # E_USAGE
+        )
+    return m.group(1), m.group(2), int(m.group(3))
+
+
+def _fetch_issue(ref: str) -> dict[str, Any]:
+    """Fetch the issue body, comments, labels, and project items via gh.
+
+    Raises E_REPO_NOT_FOUND when gh reports the issue doesn't exist or is
+    inaccessible. Other gh failures bubble up as E_GH_COMMENT_FAILED-equivalent
+    errors via the caller (post-mode only — inspect treats them as terminal).
+    """
+    owner, repo, num = _parse_ref(ref)
+    result = gh(
+        "issue", "view", str(num),
+        "--repo", f"{owner}/{repo}",
+        "--json", "number,url,title,body,labels,assignees,milestone,projectItems,comments",
+    )
+    if result.code != 0:
+        stderr = result.stderr or ""
+        if "could not resolve" in stderr.lower() or "not found" in stderr.lower():
+            die(
+                f"issue not found or inaccessible: {ref}\n"
+                f"  gh stderr: {stderr.strip()}\n"
+                f"  Fix: confirm the ref is correct and `gh auth status` shows access.",
+                code=E_REPO_NOT_FOUND,
+            )
+        die(
+            f"failed to fetch issue {ref}.\n"
+            f"  gh exit: {result.code}\n"
+            f"  gh stderr: {stderr.strip()}",
+            code=E_REPO_NOT_FOUND,
+        )
+    return json.loads(result.stdout)
+
+
+def _scan_prior_runs(comments: list[dict[str, Any]]) -> list[tuple[str, int]]:
+    """Extract (reviewer_id, n) tuples from prior review comments.
+
+    Anchored to start-of-line via re.MULTILINE so the marker must be at the
+    top of a line. Returns the full list (unsorted, in source order).
+    """
+    out_pairs: list[tuple[str, int]] = []
+    for c in comments:
+        body = c.get("body") or ""
+        for m in _RUN_MARKER_RE.finditer(body):
+            out_pairs.append((m.group(1), int(m.group(2))))
+    return out_pairs
+
+
+def _next_n_for(prior_runs: list[tuple[str, int]], reviewer_id: str) -> int:
+    matching = [n for r, n in prior_runs if r == reviewer_id]
+    return (max(matching) + 1) if matching else 1
+
+
+# --------------------------------------------------------------------------- #
+# Gate + render + post
+# --------------------------------------------------------------------------- #
+
+
+def _normalize_findings(
+    findings: list[dict[str, Any]], policy: ReviewConfig,
+) -> list[dict[str, Any]]:
+    """Apply policy normalizations to findings before gate computation.
+
+    Currently: when the repo has no project board configured, demote any
+    ``board-hygiene`` finding from ``blocker`` to ``warning`` so a missing
+    board doesn't block a repo that doesn't use boards. Returns a new list.
+    """
+    if policy.project_board_available_for_repo:
+        return findings
+    out_list: list[dict[str, Any]] = []
+    for f in findings:
+        if f.get("category") == "board-hygiene" and f.get("severity") == "blocker":
+            demoted = dict(f)
+            demoted["severity"] = "warning"
+            out_list.append(demoted)
+        else:
+            out_list.append(f)
+    return out_list
+
+
+def _compute_gate(findings: list[dict[str, Any]], policy: ReviewConfig) -> str:
+    """Compute the gate result from the findings list.
+
+    Pure function (after the normalize pass). Per spec FR-012 / data-model §4:
+      - any blocker → BLOCKED
+      - else any warning → READY_WITH_WARNINGS
+      - else → READY (nits don't gate)
+    """
+    normalized = _normalize_findings(findings, policy)
+    severities = {f.get("severity") for f in normalized}
+    if "blocker" in severities:
+        return "BLOCKED"
+    if "warning" in severities:
+        return "READY_WITH_WARNINGS"
+    return "READY"
+
+
+def _compute_metrics(findings: list[dict[str, Any]]) -> dict[str, int]:
+    blockers = sum(1 for f in findings if f.get("severity") == "blocker")
+    warnings = sum(1 for f in findings if f.get("severity") == "warning")
+    nits = sum(1 for f in findings if f.get("severity") == "nit")
+    antipatterns = sum(1 for f in findings if f.get("category") in _ANTIPATTERN_CATEGORIES)
+    pairs = sum(1 for f in findings if f.get("category") == "derived-negative-pair")
+    return {
+        "total": len(findings),
+        "blockers": blockers,
+        "warnings": warnings,
+        "nits": nits,
+        "antipatterns": antipatterns,
+        "derived_negative_pairs": pairs,
+    }
+
+
+def _escape_cell(text: str) -> str:
+    """Escape pipe and newline so a cell stays inside the markdown table."""
+    return text.replace("\\", "\\\\").replace("|", "\\|").replace("\n", " ")
+
+
+def _render_row(f: dict[str, Any]) -> str:
+    return (
+        f"| {f['id']} "
+        f"| {_escape_cell(f['category'])} "
+        f"| {f['severity']} "
+        f"| {_escape_cell(f['location'])} "
+        f"| {_escape_cell(f['summary'])} "
+        f"| {_escape_cell(f['recommendation'])} |"
+    )
+
+
+def _render_comment(
+    reviewer_id: str,
+    n: int,
+    findings: list[dict[str, Any]],
+    gate: str,
+    policy: ReviewConfig,
+    verbose: bool = False,
+) -> str:
+    """Render the consolidated review comment markdown.
+
+    Per research R6 + data-model §5: marker on line 1, gate, findings table,
+    metrics, footer. Default mode aggregates nits into one row whose Summary
+    points at --verbose; verbose mode renders each nit as its own row.
+    """
+    normalized = _normalize_findings(findings, policy)
+    metrics = _compute_metrics(normalized)
+    nits = [f for f in normalized if f.get("severity") == "nit"]
+    non_nits = [f for f in normalized if f.get("severity") != "nit"]
+
+    lines: list[str] = []
+    lines.append(f"<!-- devkit-review-issue:{reviewer_id}:run-{n} -->")
+    lines.append("")
+    lines.append("## Issue Review")
+    lines.append("")
+    lines.append(f"**Gate**: `{gate}`")
+    lines.append("")
+    lines.append("| ID | Category | Severity | Location | Summary | Recommendation |")
+    lines.append("|----|----------|----------|----------|---------|----------------|")
+    if not non_nits and not nits:
+        lines.append("| — | (none) | — | — | No findings — issue is clean. | — |")
+    for f in non_nits:
+        lines.append(_render_row(f))
+    if verbose:
+        for f in nits:
+            lines.append(_render_row(f))
+    elif nits:
+        count = len(nits)
+        plural = "s" if count != 1 else ""
+        lines.append(
+            f"| — | nit (n={count}) | nit | (multiple) "
+            f"| {count} nit-level finding{plural} — "
+            f"re-run with --verbose to inspect "
+            f"| — |"
+        )
+    lines.append("")
+    lines.append(
+        f"**Metrics**: {metrics['total']} findings · "
+        f"{metrics['blockers']} blocker{'s' if metrics['blockers'] != 1 else ''} · "
+        f"{metrics['warnings']} warning{'s' if metrics['warnings'] != 1 else ''} · "
+        f"{metrics['nits']} nit{'s' if metrics['nits'] != 1 else ''} · "
+        f"{metrics['antipatterns']} anti-pattern{'s' if metrics['antipatterns'] != 1 else ''} · "
+        f"{metrics['derived_negative_pairs']} derived-negative pair"
+        f"{'s' if metrics['derived_negative_pairs'] != 1 else ''}"
+    )
+    lines.append("")
+    lines.append(f"> Generated by `/devkit.review-issue` (run {n}). Re-run to refresh.")
+    return "\n".join(lines)
+
+
+def _post_comment(ref: str, body: str) -> str:
+    """Post the consolidated comment via gh.
+
+    Uses a tempfile (rather than extending util.run to accept stdin input) so
+    the shell seam stays unchanged and other callers aren't affected. Returns
+    the posted comment URL parsed from gh's stdout.
+    """
+    owner, repo, num = _parse_ref(ref)
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".md", delete=False, encoding="utf-8"
+    )
+    try:
+        tmp.write(body)
+        tmp.close()
+        result = gh(
+            "issue", "comment", str(num),
+            "--repo", f"{owner}/{repo}",
+            "--body-file", tmp.name,
+        )
+        if result.code != 0:
+            die(
+                f"`gh issue comment` failed for {ref}.\n"
+                f"  gh exit: {result.code}\n"
+                f"  gh stderr: {(result.stderr or '').strip()}",
+                code=E_GH_COMMENT_FAILED,
+            )
+        return (result.stdout or "").strip()
+    finally:
+        try:
+            os.unlink(tmp.name)
+        except OSError:
+            pass
+
+
+# --------------------------------------------------------------------------- #
+# JSON envelope
+# --------------------------------------------------------------------------- #
+
+
+def _build_inspect_envelope(
+    issue: dict[str, Any],
+    config: ReviewConfig,
+    prior_runs: list[tuple[str, int]],
+) -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "issue": {
+            "ref": _ref_from_issue(issue),
+            "url": issue.get("url", ""),
+        },
+        "reviewer": {"id": config.reviewer_id, "version": __version__},
+        "run": {
+            "n_next": _next_n_for(prior_runs, config.reviewer_id),
+            "started_at": _now_iso(),
+        },
+        "policy": {"project_board_required": config.project_board_required},
+        "prior_runs": [{"reviewer_id": r, "n": n} for r, n in prior_runs],
+    }
+
+
+def _emit_json_envelope(
+    issue: dict[str, Any],
+    config: ReviewConfig,
+    n: int,
+    gate: str,
+    findings: list[dict[str, Any]],
+    comment_state: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "issue": {
+            "ref": _ref_from_issue(issue),
+            "url": issue.get("url", ""),
+        },
+        "reviewer": {"id": config.reviewer_id, "version": __version__},
+        "run": {"n": n, "started_at": _now_iso()},
+        "policy": {"project_board_required": config.project_board_required},
+        "gate": gate,
+        "findings": findings,
+        "metrics": _compute_metrics(_normalize_findings(findings, config)),
+        "comment": comment_state,
+    }
+
+
+def _ref_from_issue(issue: dict[str, Any]) -> str:
+    """Derive 'owner/repo#N' from the gh JSON issue payload's url field."""
+    url = issue.get("url", "")
+    m = re.match(r"https?://github\.com/([^/]+/[^/]+)/issues/(\d+)", url)
+    if m:
+        return f"{m.group(1)}#{m.group(2)}"
+    # Fallback: just the issue number — sufficient for tests, never hit in prod.
+    return f"unknown#{issue.get('number', 0)}"
+
+
+def _now_iso() -> str:
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# --------------------------------------------------------------------------- #
+# Commands
+# --------------------------------------------------------------------------- #
+
+
+def cmd_review_issue_inspect(ref: str, reviewer_id: str | None) -> int:
+    """Fetch issue + prior runs, emit JSON envelope to stdout."""
+    config = _resolve_review_config(reviewer_id)
+    _resolve_product_request_standard_path()  # fail-fast on missing standard
+    issue = _fetch_issue(ref)
+    prior = _scan_prior_runs(issue.get("comments") or [])
+    envelope = _build_inspect_envelope(issue, config, prior)
+    print(json.dumps(envelope))
+    return 0
+
+
+_SEVERITY_LEVELS = ("blocker", "warning", "nit")
+
+
+def cmd_review_issue_post(
+    ref: str,
+    reviewer_id: str | None,
+    dry_run: bool,
+    json_output: bool,
+    verbose: bool,
+    min_severity: str,
+) -> int:
+    """Validate findings JSON from stdin → render → post (unless suppressed)."""
+    if min_severity not in _SEVERITY_LEVELS:
+        die(
+            f"--min-severity must be one of {list(_SEVERITY_LEVELS)} (got {min_severity!r})",
+            code=2,
+        )
+
+    raw = sys.stdin.read()
+    if not raw.strip():
+        die(
+            "no findings JSON on stdin. Pipe a document conforming to "
+            "review-issue-findings.schema.json into `devkit review-issue post`.",
+            code=E_FINDINGS_INVALID,
+        )
+    try:
+        findings_doc = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        die(f"findings stdin is not valid JSON: {exc}", code=E_FINDINGS_INVALID)
+    try:
+        jsonschema.validate(findings_doc, _FINDINGS_SCHEMA)
+    except jsonschema.ValidationError as exc:
+        die(
+            f"findings JSON failed schema validation.\n"
+            f"  Path: {'/'.join(str(p) for p in exc.absolute_path) or '(root)'}\n"
+            f"  Problem: {exc.message}",
+            code=E_FINDINGS_INVALID,
+        )
+
+    config = _resolve_review_config(reviewer_id)
+    _resolve_product_request_standard_path()  # fail-fast on missing standard
+    issue = _fetch_issue(ref)
+    prior = _scan_prior_runs(issue.get("comments") or [])
+    n = _next_n_for(prior, config.reviewer_id)
+    findings = findings_doc.get("findings", [])
+    gate = _compute_gate(findings, config)
+
+    # Decide whether to suppress posting under --min-severity.
+    threshold = _SEVERITY_ORDER[min_severity]
+    above_threshold = [
+        f for f in findings if _SEVERITY_ORDER.get(f.get("severity"), 0) >= threshold
+    ]
+    suppress_for_severity = len(above_threshold) == 0
+
+    body = _render_comment(config.reviewer_id, n, findings, gate, config, verbose=verbose)
+
+    comment_state: dict[str, Any]
+    if dry_run:
+        comment_state = {"posted": False, "suppression_reason": "dry-run"}
+        if not json_output:
+            out.print(body)
+            info(f"gate: {gate} (dry-run; nothing posted)")
+    elif suppress_for_severity:
+        comment_state = {"posted": False, "suppression_reason": "below-min-severity"}
+        if not json_output:
+            info(
+                f"gate: {gate} — no comment posted; "
+                f"all findings below threshold {min_severity}"
+            )
+    else:
+        url = _post_comment(ref, body)
+        comment_state = {"posted": True, "url": url} if url else {"posted": True}
+        if not json_output:
+            info(f"gate: {gate}")
+            if url:
+                info(f"posted run-{n} comment: {url}")
+            else:
+                info(f"posted run-{n} comment")
+
+    if json_output:
+        envelope = _emit_json_envelope(issue, config, n, gate, findings, comment_state)
+        # Validate our own output too (cheap; surfaces drift between code + schema).
+        try:
+            jsonschema.validate(envelope, _OUTPUT_SCHEMA)
+        except jsonschema.ValidationError as exc:  # pragma: no cover
+            log(f"internal: output envelope failed self-validation: {exc.message}")
+        print(json.dumps(envelope))
+
+    return 0

--- a/src/aidevkit/schemas/review-issue-findings.schema.json
+++ b/src/aidevkit/schemas/review-issue-findings.schema.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "DevKit Review-Issue — Findings Input",
+  "description": "Schema for the findings JSON document the slash-command markdown (LLM-side) writes and the `devkit review-issue post` Python harness validates before composing/posting the consolidated comment. Loaded by the harness via `importlib.resources.files('aidevkit.schemas')`; no `$id` is set because the schema is private to this package and not published at any URL.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "findings"],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1",
+      "description": "Findings input schema version. Bumped on breaking changes."
+    },
+    "policy_overrides": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Optional per-run policy override the slash command can supply (e.g., when the operator passes flags that map to gate-policy adjustments).",
+      "properties": {
+        "project_board_required": {"type": "boolean"}
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/finding"},
+      "description": "Ordered list of findings emitted by the analyzer. Order MUST be: anti-patterns first, then completeness, then derived-negative pairs, then ambiguity, then nits (per research.md R11)."
+    }
+  },
+  "$defs": {
+    "severity": {
+      "type": "string",
+      "enum": ["blocker", "warning", "nit"]
+    },
+    "category": {
+      "type": "string",
+      "enum": [
+        "requirement-leakage",
+        "test-plan-as-ac",
+        "chat-history-dependency",
+        "derived-negative-pair",
+        "negative-wording",
+        "completeness",
+        "ambiguity",
+        "label-hygiene",
+        "board-hygiene",
+        "scope-boundary",
+        "nit"
+      ]
+    },
+    "finding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "category", "severity", "location", "summary", "recommendation"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^F[0-9]{2,3}$",
+          "description": "Stable per-run finding ID (F01, F02, ...). Assigned in emission order. Resets on each run (per research.md R11)."
+        },
+        "category": {"$ref": "#/$defs/category"},
+        "severity": {"$ref": "#/$defs/severity"},
+        "location": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Where in the issue the finding applies (e.g., 'Acceptance Criteria, item 3', 'Body §Summary')."
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 240,
+          "description": "Single-line description, fits in the table cell."
+        },
+        "recommendation": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Suggested action or rewrite. Markdown allowed."
+        },
+        "evidence": {
+          "type": "string",
+          "description": "Optional quoted snippet from the issue body that triggered the finding. Markdown allowed."
+        },
+        "pair": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Required when category == derived-negative-pair. Names the positive and negative ACs in the same issue and the operator dispositions per FR-010.",
+          "required": ["positive_ref", "negative_ref", "dispositions"],
+          "properties": {
+            "positive_ref": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Reference to the positive AC inside the issue (e.g., 'AC item 1: \"...\"')."
+            },
+            "negative_ref": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Reference to the negative AC inside the issue (e.g., 'AC item 2: \"...\"')."
+            },
+            "entailment_explanation": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Optional one-line explanation of why the positive entails the negative."
+            },
+            "dispositions": {
+              "type": "array",
+              "minItems": 3,
+              "maxItems": 3,
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["choice", "description"],
+                "properties": {
+                  "choice": {
+                    "type": "string",
+                    "enum": ["drop", "non-goal", "risk-control"]
+                  },
+                  "description": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              },
+              "description": "Exactly three dispositions corresponding to FR-010: (a) drop the negative AC, (b) keep as non-goal documentation only, (c) escalate to risk-control invariant."
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"category": {"const": "derived-negative-pair"}}},
+          "then": {"required": ["pair"]}
+        }
+      ]
+    }
+  }
+}

--- a/src/aidevkit/schemas/review-issue-output.schema.json
+++ b/src/aidevkit/schemas/review-issue-output.schema.json
@@ -1,0 +1,198 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "DevKit Review-Issue — Output Envelope",
+  "description": "Schema for the `--json` output of `devkit review-issue post` (the canonical machine-readable payload for downstream automation per FR-017). Also describes the subset emitted by `devkit review-issue inspect`. Loaded by the harness via `importlib.resources.files('aidevkit.schemas')`; no `$id` is set because the schema is private to this package and not published at any URL. The `pair` definition is inlined below so this schema does not require cross-file `$ref` resolution.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "issue", "reviewer", "run"],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1",
+      "description": "Output schema version. Bumped on breaking changes."
+    },
+    "issue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ref", "url"],
+      "properties": {
+        "ref": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[0-9]+$"
+        },
+        "url": {"type": "string", "format": "uri"}
+      }
+    },
+    "reviewer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]{0,30}$",
+          "description": "Reviewer agent identifier (e.g., 'claude'). See research.md R4."
+        },
+        "version": {
+          "type": "string",
+          "description": "aidevkit package version, set by the harness from aidevkit.__version__."
+        }
+      }
+    },
+    "run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["started_at"],
+      "description": "Either `n` (post output, the run that just happened) or `n_next` (inspect output, the run the harness will use on the next post call) is present, never both.",
+      "properties": {
+        "n": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Run number for this reviewer-id on this issue. Present in `post` output only."
+        },
+        "n_next": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Present in `inspect` output only — the n the harness will use on the next post call."
+        },
+        "started_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp the run began."
+        }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["project_board_required"],
+      "properties": {
+        "project_board_required": {"type": "boolean"}
+      }
+    },
+    "prior_runs": {
+      "type": "array",
+      "description": "Emitted by `inspect` only. Lists prior run markers found on this issue grouped by reviewer-id.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["reviewer_id", "n"],
+        "properties": {
+          "reviewer_id": {"type": "string"},
+          "n": {"type": "integer", "minimum": 1}
+        }
+      }
+    },
+    "gate": {
+      "type": "string",
+      "enum": ["READY", "READY_WITH_WARNINGS", "BLOCKED"],
+      "description": "The gate result. Computed per data-model.md §4. Absent in `inspect` output (which is pre-analysis)."
+    },
+    "findings": {
+      "type": "array",
+      "description": "Per-finding records. Same shape as the input findings, with the harness adding nothing the LLM didn't supply except for being included verbatim. Absent in `inspect` output.",
+      "items": {"$ref": "#/$defs/finding"}
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Counts derived from the findings. Absent in `inspect` output.",
+      "required": [
+        "total", "blockers", "warnings", "nits",
+        "antipatterns", "derived_negative_pairs"
+      ],
+      "properties": {
+        "total": {"type": "integer", "minimum": 0},
+        "blockers": {"type": "integer", "minimum": 0},
+        "warnings": {"type": "integer", "minimum": 0},
+        "nits": {"type": "integer", "minimum": 0},
+        "antipatterns": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Count of findings whose category is one of: requirement-leakage, test-plan-as-ac, chat-history-dependency."
+        },
+        "derived_negative_pairs": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Count of findings whose category is derived-negative-pair."
+        }
+      }
+    },
+    "comment": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Whether and where the consolidated comment was posted. Absent in `inspect` output. In `post --dry-run` runs, posted is false and url is absent. In `post --min-severity` suppression runs, posted is false and a `suppression_reason` field names why.",
+      "required": ["posted"],
+      "properties": {
+        "posted": {"type": "boolean"},
+        "url": {"type": "string", "format": "uri"},
+        "suppression_reason": {
+          "type": "string",
+          "enum": ["dry-run", "below-min-severity"]
+        }
+      }
+    }
+  },
+  "$defs": {
+    "finding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "category", "severity", "location", "summary", "recommendation"],
+      "properties": {
+        "id": {"type": "string", "pattern": "^F[0-9]{2,3}$"},
+        "category": {
+          "type": "string",
+          "enum": [
+            "requirement-leakage",
+            "test-plan-as-ac",
+            "chat-history-dependency",
+            "derived-negative-pair",
+            "negative-wording",
+            "completeness",
+            "ambiguity",
+            "label-hygiene",
+            "board-hygiene",
+            "scope-boundary",
+            "nit"
+          ]
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["blocker", "warning", "nit"]
+        },
+        "location": {"type": "string", "minLength": 1},
+        "summary": {"type": "string", "minLength": 1, "maxLength": 240},
+        "recommendation": {"type": "string", "minLength": 1},
+        "evidence": {"type": "string"},
+        "pair": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Present only when category == derived-negative-pair. Inlined here (rather than $ref'd from review-issue-findings.schema.json) so this schema needs no cross-file resolution.",
+          "required": ["positive_ref", "negative_ref", "dispositions"],
+          "properties": {
+            "positive_ref": {"type": "string", "minLength": 1},
+            "negative_ref": {"type": "string", "minLength": 1},
+            "entailment_explanation": {"type": "string", "minLength": 1},
+            "dispositions": {
+              "type": "array",
+              "minItems": 3,
+              "maxItems": 3,
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["choice", "description"],
+                "properties": {
+                  "choice": {
+                    "type": "string",
+                    "enum": ["drop", "non-goal", "risk-control"]
+                  },
+                  "description": {"type": "string", "minLength": 1}
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/aidevkit/util.py
+++ b/src/aidevkit/util.py
@@ -35,6 +35,8 @@ E_CHECK_UPDATE_INDEX_UNAVAILABLE = 27
 E_CONFIG_INVALID = 70
 E_CATALOG_INVALID = 71
 E_TEMPLATE_COLLISION = 72
+E_FINDINGS_INVALID = 74
+E_GH_COMMENT_FAILED = 75
 
 out = Console(markup=False, highlight=False, soft_wrap=True)
 err = Console(stderr=True, markup=False, highlight=False, soft_wrap=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,6 +44,8 @@ EXPECTED_HELP = """\
 │ update        Upgrade DevKit to the latest release, then run doctor.         │
 │ check-update  Check whether a newer aidevkit release is available.           │
 │ version       Print the installed aidevkit version.                          │
+│ review-issue  Review a GitHub issue against the App Empire product-request   │
+│               standard.                                                      │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 """
 

--- a/tests/test_review_issue.py
+++ b/tests/test_review_issue.py
@@ -1,0 +1,601 @@
+"""Tests for `aidevkit.review_issue` (DevKit#17).
+
+All `gh` invocations flow through the `subprocess_capture` fixture from
+``conftest.py`` (which monkeypatches ``aidevkit.util.run`` — the project-wide
+hermeticity seam). No real `gh` or network calls are made.
+
+Helpers in this module:
+- ``make_issue_fixture``: build a synthetic gh JSON response.
+- ``valid_findings_doc`` / ``invalid_findings_doc``: minimal findings docs for
+  schema-validation tests.
+- ``cortex_expertise_issue_fixture``: the DevKit#17 motivating example
+  (positive AC: env-var config; negative AC: does-not-require-cortex-config).
+- ``standard_path_env``: monkeypatch the product-request standard path so the
+  runtime existence check finds it during tests.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import pytest
+import typer
+
+from aidevkit import review_issue
+from aidevkit.util import RunResult
+
+# --------------------------------------------------------------------------- #
+# Fixtures and helpers (T011)
+# --------------------------------------------------------------------------- #
+
+
+def make_issue_fixture(
+    *,
+    body: str = "## Summary\nTest issue.\n",
+    title: str = "Test issue",
+    number: int = 42,
+    repo: str = "App-Empire-LLC/DevKit",
+    comments: list[dict[str, Any]] | None = None,
+    labels: list[dict[str, Any]] | None = None,
+    project_items: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "number": number,
+        "url": f"https://github.com/{repo}/issues/{number}",
+        "title": title,
+        "body": body,
+        "labels": labels or [],
+        "assignees": [],
+        "milestone": None,
+        "projectItems": project_items or [],
+        "comments": comments or [],
+    }
+
+
+def cortex_expertise_issue_fixture() -> dict[str, Any]:
+    """The DevKit#17 motivating example.
+
+    Body matches `quickstart.md` § "Worked example: derived-negative AC pair".
+    """
+    body = (
+        "## Summary\n"
+        "Extract cortex-expertise as a standalone service.\n\n"
+        "## Acceptance Criteria\n\n"
+        "- Configuration delivered via a single environment variable "
+        "(plain text or base64), read at startup.\n"
+        "- The service starts without requiring cortex-config or any "
+        "external configuration service.\n"
+    )
+    return make_issue_fixture(body=body, title="Extract cortex-expertise", number=7,
+                              repo="App-Empire-LLC/cortex-expertise")
+
+
+def valid_findings_doc(
+    findings: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {"schema_version": "1", "findings": findings or []}
+
+
+def invalid_findings_doc(missing_field: str = "findings") -> dict[str, Any]:
+    base = {"schema_version": "1", "findings": []}
+    base.pop(missing_field, None)
+    return base
+
+
+def make_finding(
+    fid: str = "F01",
+    *,
+    category: str = "completeness",
+    severity: str = "warning",
+    location: str = "Body §Summary",
+    summary: str = "Example finding",
+    recommendation: str = "Example recommendation",
+    evidence: str | None = None,
+    pair: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    f: dict[str, Any] = {
+        "id": fid,
+        "category": category,
+        "severity": severity,
+        "location": location,
+        "summary": summary,
+        "recommendation": recommendation,
+    }
+    if evidence is not None:
+        f["evidence"] = evidence
+    if pair is not None:
+        f["pair"] = pair
+    return f
+
+
+def cortex_pair_finding() -> dict[str, Any]:
+    """A derived-negative-pair finding matching the cortex-expertise example."""
+    return make_finding(
+        fid="F02",
+        category="derived-negative-pair",
+        severity="warning",
+        location="Acceptance Criteria, items 1-2",
+        summary="AC-2 (does not require cortex-config) is entailed by AC-1 (loads from env var).",
+        recommendation=(
+            "Drop the negative AC, keep as non-goal docs only, or escalate to risk control."
+        ),
+        pair={
+            "positive_ref": "AC-1: loads config from a single env var",
+            "negative_ref": "AC-2: does not require cortex-config",
+            "entailment_explanation": "Verifying AC-1 (env-var config works) verifies AC-2.",
+            "dispositions": [
+                {"choice": "drop", "description": "Let SpecKit infer the negative."},
+                {"choice": "non-goal", "description": "Keep as non-goal documentation only."},
+                {"choice": "risk-control", "description": "Escalate to a hardening test (rare)."},
+            ],
+        },
+    )
+
+
+@pytest.fixture
+def standard_path_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Materialise a stub product-request standard and point the resolver at it.
+
+    The resolver checks ``$DEVKIT_REVIEW_ISSUE_STANDARD_PATH`` first; setting
+    that lets tests run from any cwd without dragging in the real appire_docs.
+    """
+    standard = tmp_path / "product_requests.md"
+    standard.write_text("# Product Requests\nStub for tests.\n")
+    monkeypatch.setenv("DEVKIT_REVIEW_ISSUE_STANDARD_PATH", str(standard))
+    return standard
+
+
+@pytest.fixture
+def feed_findings(monkeypatch: pytest.MonkeyPatch):
+    """Helper that stuffs a JSON document into stdin for `cmd_review_issue_post`."""
+    def _feed(doc: dict[str, Any]) -> None:
+        import io
+        monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(doc)))
+    return _feed
+
+
+# --------------------------------------------------------------------------- #
+# Phase 3: User Story 1 tests (T012–T020a)
+# --------------------------------------------------------------------------- #
+
+
+def test_inspect_emits_envelope(
+    subprocess_capture, standard_path_env, capsys
+) -> None:
+    """T012 — inspect emits a JSON envelope conforming to the schema."""
+    issue = make_issue_fixture()
+    subprocess_capture.queue(RunResult(code=0, stdout=json.dumps(issue), stderr=""))
+    rc = review_issue.cmd_review_issue_inspect(
+        ref="App-Empire-LLC/DevKit#42", reviewer_id=None
+    )
+    assert rc == 0
+    captured = capsys.readouterr().out
+    envelope = json.loads(captured)
+    # Validate against the inspect-subset of the output schema.
+    jsonschema.validate(envelope, review_issue._OUTPUT_SCHEMA)
+    assert envelope["run"]["n_next"] == 1
+    assert envelope["reviewer"]["id"] == "claude"
+    assert envelope["issue"]["ref"] == "App-Empire-LLC/DevKit#42"
+
+
+def test_gate_blocked_when_blocker_present(
+    subprocess_capture, standard_path_env, capsys, feed_findings
+) -> None:
+    """T013 — any blocker → BLOCKED in both rendered comment and JSON."""
+    feed_findings(valid_findings_doc([
+        make_finding(severity="blocker", category="completeness",
+                     summary="No Acceptance Criteria section"),
+    ]))
+    issue = make_issue_fixture()
+    subprocess_capture.queue(RunResult(code=0, stdout=json.dumps(issue), stderr=""))
+    subprocess_capture.queue(RunResult(  # for the post call
+        code=0, stdout="https://github.com/App-Empire-LLC/DevKit/issues/42#issuecomment-1\n",
+        stderr=""))
+    rc = review_issue.cmd_review_issue_post(
+        ref="App-Empire-LLC/DevKit#42", reviewer_id=None,
+        dry_run=True, json_output=True, verbose=False, min_severity="warning",
+    )
+    assert rc == 0
+    out_text = capsys.readouterr().out
+    envelope = json.loads(out_text)
+    assert envelope["gate"] == "BLOCKED"
+
+
+def test_gate_warnings_when_warnings_only(
+    subprocess_capture, standard_path_env, capsys, feed_findings
+) -> None:
+    """T014 — only warnings → READY_WITH_WARNINGS."""
+    feed_findings(valid_findings_doc([
+        make_finding(severity="warning"),
+    ]))
+    issue = make_issue_fixture()
+    subprocess_capture.queue(RunResult(code=0, stdout=json.dumps(issue), stderr=""))
+    rc = review_issue.cmd_review_issue_post(
+        ref="App-Empire-LLC/DevKit#42", reviewer_id=None,
+        dry_run=True, json_output=True, verbose=False, min_severity="warning",
+    )
+    assert rc == 0
+    envelope = json.loads(capsys.readouterr().out)
+    assert envelope["gate"] == "READY_WITH_WARNINGS"
+
+
+def test_gate_ready_when_clean(
+    subprocess_capture, standard_path_env, capsys, feed_findings
+) -> None:
+    """T015 — empty or nit-only findings → READY."""
+    for findings_list in ([], [make_finding(severity="nit")]):
+        feed_findings(valid_findings_doc(findings_list))
+        issue = make_issue_fixture()
+        subprocess_capture.queue(RunResult(code=0, stdout=json.dumps(issue), stderr=""))
+        rc = review_issue.cmd_review_issue_post(
+            ref="App-Empire-LLC/DevKit#42", reviewer_id=None,
+            dry_run=True, json_output=True, verbose=False, min_severity="warning",
+        )
+        assert rc == 0
+        envelope = json.loads(capsys.readouterr().out)
+        assert envelope["gate"] == "READY"
+
+
+def test_run_n_increments_per_reviewer(
+    subprocess_capture, standard_path_env, capsys
+) -> None:
+    """T016 — run-N counter is per-reviewer-id."""
+    issue = make_issue_fixture(comments=[
+        {"body": "<!-- devkit-review-issue:claude:run-1 -->\n## Issue Review\n..."},
+        {"body": "<!-- devkit-review-issue:claude:run-2 -->\n## Issue Review\n..."},
+    ])
+    # claude → 3
+    subprocess_capture.queue(RunResult(code=0, stdout=json.dumps(issue), stderr=""))
+    review_issue.cmd_review_issue_inspect(
+        ref="App-Empire-LLC/DevKit#42", reviewer_id="claude"
+    )
+    env_claude = json.loads(capsys.readouterr().out)
+    assert env_claude["run"]["n_next"] == 3
+    # gpt → 1 (no prior runs)
+    subprocess_capture.queue(RunResult(code=0, stdout=json.dumps(issue), stderr=""))
+    review_issue.cmd_review_issue_inspect(
+        ref="App-Empire-LLC/DevKit#42", reviewer_id="gpt"
+    )
+    env_gpt = json.loads(capsys.readouterr().out)
+    assert env_gpt["run"]["n_next"] == 1
+
+
+def test_derived_negative_pair_finding(
+    subprocess_capture, standard_path_env, capsys, feed_findings
+) -> None:
+    """T017 + SC-007 — cortex-expertise pair renders + counts in metrics."""
+    feed_findings(valid_findings_doc([cortex_pair_finding()]))
+    issue = cortex_expertise_issue_fixture()
+    subprocess_capture.queue(RunResult(code=0, stdout=json.dumps(issue), stderr=""))
+    rc = review_issue.cmd_review_issue_post(
+        ref="App-Empire-LLC/cortex-expertise#7", reviewer_id=None,
+        dry_run=True, json_output=False, verbose=False, min_severity="warning",
+    )
+    assert rc == 0
+    out_text = capsys.readouterr().out
+    assert "F02" in out_text
+    assert "derived-negative-pair" in out_text
+    assert "1 derived-negative pair" in out_text
+
+
+def test_post_calls_gh_comment(
+    subprocess_capture, standard_path_env, feed_findings
+) -> None:
+    """T018 — happy-path post invokes gh issue comment exactly once."""
+    feed_findings(valid_findings_doc([make_finding(severity="warning")]))
+    issue = make_issue_fixture()
+    subprocess_capture.queue(RunResult(code=0, stdout=json.dumps(issue), stderr=""))
+    subprocess_capture.queue(RunResult(
+        code=0, stdout="https://github.com/App-Empire-LLC/DevKit/issues/42#issuecomment-1\n",
+        stderr=""))
+    rc = review_issue.cmd_review_issue_post(
+        ref="App-Empire-LLC/DevKit#42", reviewer_id=None,
+        dry_run=False, json_output=False, verbose=False, min_severity="warning",
+    )
+    assert rc == 0
+    comment_calls = [
+        c for c in subprocess_capture.calls
+        if len(c["cmd"]) >= 3 and c["cmd"][:3] == ["gh", "issue", "comment"]
+    ]
+    assert len(comment_calls) == 1
+    # Confirm no edit/delete subcommands were issued.
+    edit_calls = [
+        c for c in subprocess_capture.calls
+        if "edit" in c["cmd"] or "delete" in c["cmd"]
+    ]
+    assert edit_calls == []
+
+
+def test_post_emits_run_marker(
+    subprocess_capture, standard_path_env, capsys, feed_findings
+) -> None:
+    """T019 — the rendered comment's first line is the run marker."""
+    feed_findings(valid_findings_doc([make_finding(severity="warning")]))
+    issue = make_issue_fixture()
+    subprocess_capture.queue(RunResult(code=0, stdout=json.dumps(issue), stderr=""))
+    rc = review_issue.cmd_review_issue_post(
+        ref="App-Empire-LLC/DevKit#42", reviewer_id=None,
+        dry_run=True, json_output=False, verbose=False, min_severity="warning",
+    )
+    assert rc == 0
+    body = capsys.readouterr().out
+    first_line = body.lstrip().splitlines()[0]
+    import re as _re
+    assert _re.match(r"^<!--\s*devkit-review-issue:claude:run-1\s*-->$", first_line)
+
+
+def test_findings_schema_rejects_bad_input(
+    subprocess_capture, standard_path_env, feed_findings
+) -> None:
+    """T020 — malformed findings JSON exits with E_FINDINGS_INVALID and posts nothing."""
+    # Missing the required `findings` field.
+    feed_findings(invalid_findings_doc(missing_field="findings"))
+    with pytest.raises(typer.Exit) as exc_info:
+        review_issue.cmd_review_issue_post(
+            ref="App-Empire-LLC/DevKit#42", reviewer_id=None,
+            dry_run=False, json_output=False, verbose=False, min_severity="warning",
+        )
+    assert exc_info.value.exit_code == 74  # E_FINDINGS_INVALID
+    comment_calls = [
+        c for c in subprocess_capture.calls
+        if len(c["cmd"]) >= 3 and c["cmd"][:3] == ["gh", "issue", "comment"]
+    ]
+    assert comment_calls == []
+
+    # Also: derived-negative-pair without the required `pair` object.
+    bad_doc = valid_findings_doc([
+        make_finding(category="derived-negative-pair", severity="warning"),  # no pair=
+    ])
+    feed_findings(bad_doc)
+    with pytest.raises(typer.Exit) as exc_info2:
+        review_issue.cmd_review_issue_post(
+            ref="App-Empire-LLC/DevKit#42", reviewer_id=None,
+            dry_run=False, json_output=False, verbose=False, min_severity="warning",
+        )
+    assert exc_info2.value.exit_code == 74
+
+
+def test_fetch_error_is_actionable(
+    subprocess_capture, standard_path_env, feed_findings, capsys
+) -> None:
+    """T020a + FR-005 — issue not found exits cleanly with E_REPO_NOT_FOUND, no comment."""
+    feed_findings(valid_findings_doc([make_finding(severity="warning")]))
+    subprocess_capture.queue(RunResult(
+        code=1, stdout="",
+        stderr="GraphQL: Could not resolve to an Issue with the number of 999. (repository.issue)",
+    ))
+    with pytest.raises(typer.Exit) as exc_info:
+        review_issue.cmd_review_issue_post(
+            ref="App-Empire-LLC/DevKit#999", reviewer_id=None,
+            dry_run=False, json_output=False, verbose=False, min_severity="warning",
+        )
+    assert exc_info.value.exit_code == 13  # E_REPO_NOT_FOUND
+    comment_calls = [
+        c for c in subprocess_capture.calls
+        if len(c["cmd"]) >= 3 and c["cmd"][:3] == ["gh", "issue", "comment"]
+    ]
+    assert comment_calls == []
+    captured_err = capsys.readouterr().err
+    assert "DevKit#999" in captured_err
+    assert "Could not resolve" in captured_err
+
+
+# --------------------------------------------------------------------------- #
+# Phase 4: User Story 2 — dry-run (T027, T028)
+# --------------------------------------------------------------------------- #
+
+
+def test_dry_run_does_not_post(
+    subprocess_capture, standard_path_env, capsys, feed_findings
+) -> None:
+    """T027 — --dry-run records zero comment calls and prints markdown."""
+    feed_findings(valid_findings_doc([make_finding(severity="warning")]))
+    issue = make_issue_fixture()
+    subprocess_capture.queue(RunResult(code=0, stdout=json.dumps(issue), stderr=""))
+    rc = review_issue.cmd_review_issue_post(
+        ref="App-Empire-LLC/DevKit#42", reviewer_id=None,
+        dry_run=True, json_output=False, verbose=False, min_severity="warning",
+    )
+    assert rc == 0
+    comment_calls = [
+        c for c in subprocess_capture.calls
+        if len(c["cmd"]) >= 3 and c["cmd"][:3] == ["gh", "issue", "comment"]
+    ]
+    assert comment_calls == []
+    out_text = capsys.readouterr().out
+    assert "## Issue Review" in out_text
+
+
+def test_dry_run_prints_markdown(
+    subprocess_capture, standard_path_env, capsys, feed_findings
+) -> None:
+    """T028 — dry-run output contains marker, gate line, and table header."""
+    feed_findings(valid_findings_doc([make_finding(severity="warning")]))
+    issue = make_issue_fixture()
+    subprocess_capture.queue(RunResult(code=0, stdout=json.dumps(issue), stderr=""))
+    rc = review_issue.cmd_review_issue_post(
+        ref="App-Empire-LLC/DevKit#42", reviewer_id=None,
+        dry_run=True, json_output=False, verbose=False, min_severity="warning",
+    )
+    assert rc == 0
+    out_text = capsys.readouterr().out
+    assert "<!-- devkit-review-issue:claude:run-" in out_text
+    assert "**Gate**:" in out_text
+    assert "| ID | Category | Severity | Location | Summary | Recommendation |" in out_text
+
+
+# --------------------------------------------------------------------------- #
+# Phase 5: User Story 3 — JSON (T031, T032, T033)
+# --------------------------------------------------------------------------- #
+
+
+def test_json_output_validates_schema(
+    subprocess_capture, standard_path_env, capsys, feed_findings
+) -> None:
+    """T031 — --json output validates against review-issue-output.schema.json."""
+    feed_findings(valid_findings_doc([make_finding(severity="warning")]))
+    issue = make_issue_fixture()
+    subprocess_capture.queue(RunResult(code=0, stdout=json.dumps(issue), stderr=""))
+    subprocess_capture.queue(RunResult(
+        code=0, stdout="https://github.com/App-Empire-LLC/DevKit/issues/42#issuecomment-1\n",
+        stderr=""))
+    rc = review_issue.cmd_review_issue_post(
+        ref="App-Empire-LLC/DevKit#42", reviewer_id=None,
+        dry_run=False, json_output=True, verbose=False, min_severity="warning",
+    )
+    assert rc == 0
+    envelope = json.loads(capsys.readouterr().out)
+    jsonschema.validate(envelope, review_issue._OUTPUT_SCHEMA)
+
+
+def test_json_dry_run_combination(
+    subprocess_capture, standard_path_env, capsys, feed_findings
+) -> None:
+    """T032 — --json + --dry-run emits envelope and posts nothing."""
+    feed_findings(valid_findings_doc([make_finding(severity="warning")]))
+    issue = make_issue_fixture()
+    subprocess_capture.queue(RunResult(code=0, stdout=json.dumps(issue), stderr=""))
+    rc = review_issue.cmd_review_issue_post(
+        ref="App-Empire-LLC/DevKit#42", reviewer_id=None,
+        dry_run=True, json_output=True, verbose=False, min_severity="warning",
+    )
+    assert rc == 0
+    comment_calls = [
+        c for c in subprocess_capture.calls
+        if len(c["cmd"]) >= 3 and c["cmd"][:3] == ["gh", "issue", "comment"]
+    ]
+    assert comment_calls == []
+    envelope = json.loads(capsys.readouterr().out)
+    assert envelope["comment"]["posted"] is False
+    assert envelope["comment"]["suppression_reason"] == "dry-run"
+
+
+def test_json_gate_matches_comment(
+    subprocess_capture, standard_path_env, capsys, feed_findings
+) -> None:
+    """T033 — gate string in JSON matches `**Gate**: <value>` in comment (SC-004)."""
+    cases = [
+        ([make_finding(severity="blocker")], "BLOCKED"),
+        ([make_finding(severity="warning")], "READY_WITH_WARNINGS"),
+        ([], "READY"),
+    ]
+    for findings, expected_gate in cases:
+        # JSON pass
+        feed_findings(valid_findings_doc(findings))
+        issue = make_issue_fixture()
+        subprocess_capture.queue(RunResult(code=0, stdout=json.dumps(issue), stderr=""))
+        review_issue.cmd_review_issue_post(
+            ref="App-Empire-LLC/DevKit#42", reviewer_id=None,
+            dry_run=True, json_output=True, verbose=False, min_severity="warning",
+        )
+        envelope = json.loads(capsys.readouterr().out)
+        assert envelope["gate"] == expected_gate
+
+        # Markdown pass — same fixtures
+        feed_findings(valid_findings_doc(findings))
+        subprocess_capture.queue(RunResult(code=0, stdout=json.dumps(issue), stderr=""))
+        review_issue.cmd_review_issue_post(
+            ref="App-Empire-LLC/DevKit#42", reviewer_id=None,
+            dry_run=True, json_output=False, verbose=False, min_severity="warning",
+        )
+        body = capsys.readouterr().out
+        assert f"**Gate**: `{expected_gate}`" in body
+
+
+# --------------------------------------------------------------------------- #
+# Phase 6: User Story 4 — verbose / min-severity (T037, T038, T039, T040)
+# --------------------------------------------------------------------------- #
+
+
+def test_verbose_includes_nits_inline(
+    subprocess_capture, standard_path_env, capsys, feed_findings
+) -> None:
+    """T037 — --verbose renders each nit as its own row."""
+    feed_findings(valid_findings_doc([
+        make_finding(fid="F01", severity="warning"),
+        make_finding(fid="F02", severity="nit"),
+        make_finding(fid="F03", severity="nit"),
+    ]))
+    issue = make_issue_fixture()
+    subprocess_capture.queue(RunResult(code=0, stdout=json.dumps(issue), stderr=""))
+    rc = review_issue.cmd_review_issue_post(
+        ref="App-Empire-LLC/DevKit#42", reviewer_id=None,
+        dry_run=True, json_output=False, verbose=True, min_severity="warning",
+    )
+    assert rc == 0
+    body = capsys.readouterr().out
+    # Each finding ID appears as a row in the table.
+    assert "| F01 " in body
+    assert "| F02 " in body
+    assert "| F03 " in body
+
+
+def test_default_aggregates_nits(
+    subprocess_capture, standard_path_env, capsys, feed_findings
+) -> None:
+    """T038 — without --verbose, nits are aggregated into one row."""
+    feed_findings(valid_findings_doc([
+        make_finding(fid="F01", severity="warning"),
+        make_finding(fid="F02", severity="nit"),
+        make_finding(fid="F03", severity="nit"),
+    ]))
+    issue = make_issue_fixture()
+    subprocess_capture.queue(RunResult(code=0, stdout=json.dumps(issue), stderr=""))
+    rc = review_issue.cmd_review_issue_post(
+        ref="App-Empire-LLC/DevKit#42", reviewer_id=None,
+        dry_run=True, json_output=False, verbose=False, min_severity="warning",
+    )
+    assert rc == 0
+    body = capsys.readouterr().out
+    assert "| F01 " in body          # warning still rendered as its own row
+    assert "| F02 " not in body      # individual nits aggregated away
+    assert "| F03 " not in body
+    assert "nit (n=2)" in body
+    assert "re-run with --verbose" in body
+
+
+def test_min_severity_suppresses_post(
+    subprocess_capture, standard_path_env, capsys, feed_findings
+) -> None:
+    """T039 — --min-severity warning suppresses post when only nits exist."""
+    feed_findings(valid_findings_doc([
+        make_finding(fid="F01", severity="nit"),
+        make_finding(fid="F02", severity="nit"),
+    ]))
+    issue = make_issue_fixture()
+    subprocess_capture.queue(RunResult(code=0, stdout=json.dumps(issue), stderr=""))
+    rc = review_issue.cmd_review_issue_post(
+        ref="App-Empire-LLC/DevKit#42", reviewer_id=None,
+        dry_run=False, json_output=False, verbose=False, min_severity="warning",
+    )
+    assert rc == 0
+    comment_calls = [
+        c for c in subprocess_capture.calls
+        if len(c["cmd"]) >= 3 and c["cmd"][:3] == ["gh", "issue", "comment"]
+    ]
+    assert comment_calls == []
+    captured = capsys.readouterr()
+    # Status line goes through info() → out.print → captured stdout, but the
+    # gate line is the one that always shows up via the info() helper.
+    combined = captured.out + captured.err
+    assert "below threshold" in combined or "no comment posted" in combined
+    assert "READY" in combined  # gate still computed and shown
+
+
+def test_min_severity_emits_suppression_in_json(
+    subprocess_capture, standard_path_env, capsys, feed_findings
+) -> None:
+    """T040 — JSON envelope reflects min-severity suppression."""
+    feed_findings(valid_findings_doc([make_finding(severity="nit")]))
+    issue = make_issue_fixture()
+    subprocess_capture.queue(RunResult(code=0, stdout=json.dumps(issue), stderr=""))
+    rc = review_issue.cmd_review_issue_post(
+        ref="App-Empire-LLC/DevKit#42", reviewer_id=None,
+        dry_run=False, json_output=True, verbose=False, min_severity="warning",
+    )
+    assert rc == 0
+    envelope = json.loads(capsys.readouterr().out)
+    assert envelope["comment"]["posted"] is False
+    assert envelope["comment"]["suppression_reason"] == "below-min-severity"

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,7 @@ name = "aidevkit"
 version = "0.4.0"
 source = { editable = "." }
 dependencies = [
+    { name = "jsonschema" },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "typer" },
@@ -22,6 +23,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "jsonschema", specifier = ">=4" },
     { name = "jsonschema", marker = "extra == 'test'", specifier = ">=4" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=5" },


### PR DESCRIPTION
## Summary

- Adds `/devkit.review-issue` — a hybrid LLM + Python harness command that reviews a GitHub issue against `appire_docs/docs/engineering/standards/product_requests.md` and posts a single consolidated review comment with a `READY` / `READY_WITH_WARNINGS` / `BLOCKED` gate.
- Architecture mirrors `/speckit.analyze`: slash-command markdown drives the LLM-side semantic analysis (anti-pattern detection, AC entailment, ambiguity, derived-negative pairs); Python harness (`devkit review-issue inspect` / `devkit review-issue post`) handles I/O, schema validation, comment composition, and the JSON envelope.
- Two new exit codes (`74 E_FINDINGS_INVALID`, `75 E_GH_COMMENT_FAILED`); `jsonschema` promoted from test-only to runtime dep (validates LLM-supplied findings before the harness composes a comment).

Closes #17.

## Test plan

- [x] 19 new hermetic tests in `tests/test_review_issue.py` — covers all four user stories (US1 review+gate, US2 dry-run, US3 JSON, US4 verbose / min-severity), SC-004 gate-string consistency, SC-007 derived-negative pair handling, FR-005 fetch-error path, FR-022 marker discipline.
- [x] `cd DevKit && uv run pytest -q` — **310 passed in 10.69s**, zero regressions.
- [x] `cd DevKit && uv run ruff check .` — clean.
- [x] Hermeticity confirmed: every `gh` call routes through `aidevkit.util.run`; the autouse `_fail_on_unmocked_shell` guard fired zero times.
- [x] Dogfooded against [App-Empire-LLC/cortex-nexus-mobile-client#3](https://github.com/App-Empire-LLC/cortex-nexus-mobile-client/issues/3) — surfaced and fixed a real harness bug (`gh` doesn't accept `owner/repo#N` for `issue view` / `issue comment`; needs `--repo` + bare number, mirroring `bootstrap.py`'s `_parse_issue_ref`). Without that fix the command was unusable end-to-end.
- [ ] Operator: full quickstart walk (T046 — manual, deferred to operator).

## Spec / plan / tasks

Lives at `specs/001-review-issue/` in the workspace root (not part of this repo's tree). Includes spec.md, plan.md, research.md, data-model.md, contracts/ (CLI contract + 2 JSON Schemas), quickstart.md, tasks.md (49 tasks, 48 complete), and creep.md (a meta-analysis of where the spec exceeded the issue, with the high-cost creep items K1–K4 cut before implementation).

## Follow-ups (filed)

- #48 — `--with-children` (context fetch) and `--recursive` (leaf-first review)
- #49 — detector tuning: flag concepts not headings; demote AC-vs-DoD to nit
- #50 — reframe `negative-wording` detector → `verification-scope-risk`

Companion PR: [App-Empire-LLC/appire_docs#XX](https://github.com/App-Empire-LLC/appire_docs/pulls) (push-left: standard updates and issue templates).