### PR TITLE
review-issue: rename standard reference + make standard path configurable (#52)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aidevkit"
-version = "0.4.0"
+version = "0.5.0"
 description = "Companion tooling for GitHub Spec-Kit — per-issue git worktrees, Claude Code slash commands, and workflow helpers."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/aidevkit/cli.py
+++ b/src/aidevkit/cli.py
@@ -241,7 +241,7 @@ def version() -> None:
 # (`inspect` and `post`) compose into the `/devkit.review-issue` slash command.
 review_issue_app = typer.Typer(
     name="review-issue",
-    help="Review a GitHub issue against the App Empire product-request standard.",
+    help="Review a GitHub issue against the App Empire issue-authoring standard.",
     no_args_is_help=True,
 )
 app.add_typer(review_issue_app, name="review-issue")

--- a/src/aidevkit/commands/devkit.review-issue.md
+++ b/src/aidevkit/commands/devkit.review-issue.md
@@ -1,10 +1,10 @@
 ---
-description: Review a GitHub issue against the App Empire product-request standard before SpecKit handoff
+description: Review a GitHub issue against the App Empire issue-authoring standard before SpecKit handoff
 ---
 
 # /devkit.review-issue
 
-Pre-SpecKit quality gate. Reviews a GitHub issue against `appire_docs/docs/engineering/standards/product_requests.md` and posts a single consolidated review comment with a `READY` / `READY_WITH_WARNINGS` / `BLOCKED` gate.
+Pre-SpecKit quality gate. Reviews a GitHub issue against `appire_docs/docs/engineering/standards/issue_authoring.md` and posts a single consolidated review comment with a `READY` / `READY_WITH_WARNINGS` / `BLOCKED` gate.
 
 This command is operator-explicit only. There is no auto-trigger on issue events or comment activity.
 
@@ -42,13 +42,13 @@ Parse the JSON envelope it prints. You'll use `issue.ref`, `issue.url`, the next
 
 ### Step 2 — read the canon
 
-Read `appire_docs/docs/engineering/standards/product_requests.md`. It's the source of truth for everything below; do not rely on training data.
+Read `appire_docs/docs/engineering/standards/issue_authoring.md`. It's the source of truth for everything below; do not rely on training data.
 
 ### Step 3 — apply the detectors
 
 Build a findings list classified by category and severity. Each finding is one of:
 
-**Review Checklist (9 questions from `product_requests.md`)** — for each, emit a `completeness` finding when the answer is "no" or "unclear":
+**Review Checklist (9 questions from `issue_authoring.md`)** — for each, emit a `completeness` finding when the answer is "no" or "unclear":
 
 1. Does this issue describe what needs to be true?
 2. Did the author accidentally describe how to build it?
@@ -60,7 +60,7 @@ Build a findings list classified by category and severity. Each finding is one o
 8. Could Claude Code over-constrain the spec because the issue is too specific?
 9. Does the issue stand alone without relying on chat history?
 
-**Definition of Done for Issue Authoring (8 items from `product_requests.md`)** — for each, emit a `completeness` finding when the item isn't satisfied:
+**Definition of Done for Issue Authoring (8 items from `issue_authoring.md`)** — for each, emit a `completeness` finding when the item isn't satisfied:
 
 1. Actor and desired outcome are clear.
 2. Acceptance criteria describe observable outcomes.
@@ -71,7 +71,7 @@ Build a findings list classified by category and severity. Each finding is one o
 7. SpecKit can generate a spec without inheriting accidental implementation requirements.
 8. Claude Code has enough context to proceed without guessing product intent.
 
-**Anti-patterns (3, from `product_requests.md`)** — emit one finding per detected instance:
+**Anti-patterns (3, from `issue_authoring.md`)** — emit one finding per detected instance:
 
 - `requirement-leakage` — implementation choices presented as acceptance criteria (e.g., "Use Ory Kratos for auth").
 - `test-plan-as-ac` — acceptance criteria that name test mechanics rather than expected behavior.
@@ -183,7 +183,7 @@ Use this mode when feeding downstream automation (e.g., a future "promote to Rea
 
 - **2** `E_USAGE` — bad ref or unknown flag.
 - **13** `E_REPO_NOT_FOUND` — gh says the issue or repo doesn't exist or isn't accessible.
-- **70** `E_CONFIG_INVALID` — `.devkit/config.yaml` `review_issue` block fails schema, or the hardcoded product-request standard path can't be found in this workspace (likely cause: `appire_docs` not checked out as a sibling repo).
+- **70** `E_CONFIG_INVALID` — `.devkit/config.yaml` `review_issue` block fails schema, or the issue-authoring standard's resolved path can't be found (likely cause: `appire_docs` not checked out as a sibling repo, or a stale `review_issue.standard_path` / `DEVKIT_REVIEW_ISSUE_STANDARD_PATH` env var). The error message names both the attempted path and which precedence source supplied it.
 - **74** `E_FINDINGS_INVALID` — the findings JSON failed schema validation; the harness posts no comment.
 - **75** `E_GH_COMMENT_FAILED` — `gh issue comment` returned non-zero; the issue thread is unchanged.
 
@@ -191,7 +191,7 @@ Use this mode when feeding downstream automation (e.g., a future "promote to Rea
 
 - One consolidated comment per run. The slash command never posts per-finding comments.
 - Each comment carries an HTML marker `<!-- devkit-review-issue:<reviewer-id>:run-N -->` on its first line. Re-runs add a new comment with an incremented `run-N`; prior comments are not edited or deleted by the harness.
-- The product-request standard's path is locked at `appire_docs/docs/engineering/standards/product_requests.md` per spec FR-006 (configurability deferred — see `specs/001-review-issue/creep.md` K3).
+- The issue-authoring standard's path defaults to `appire_docs/docs/engineering/standards/issue_authoring.md`, configurable via `review_issue.standard_path` in `.devkit/config.yaml`. The env var `DEVKIT_REVIEW_ISSUE_STANDARD_PATH` overrides both (test/operator hook). Precedence is strict: a higher-precedence source, once set, is never overridden by a lower-precedence one even if its path doesn't resolve. See spec `001-review-issue-standard-path`.
 - The default gate policy (per spec FR-012):
   - `BLOCKED` — no summary, no AC section, no observable outcome, all ACs are implementation detail (Requirement Leakage), or issue not on a project board (when the repo has one).
   - `READY_WITH_WARNINGS` — ambiguity placeholders ("TBD", "we'll figure out"), AC duplication or entailment, broad prohibitions, missing labels, missing parent-epic reference where applicable, negatives needing operator triage.

--- a/src/aidevkit/config.py
+++ b/src/aidevkit/config.py
@@ -191,17 +191,33 @@ _REVIEWER_ID_RE = re.compile(r"^[a-z][a-z0-9-]{0,30}$")
 class ReviewIssueConfig:
     """Optional `review_issue` block from `.devkit/config.yaml`.
 
-    Two fields per spec/research R5 (creep K3/K4 cut the rest):
-    - reviewer_id: identity for run-marker grouping (default "claude")
-    - project_board_required: whether absence of a project board is blocker (default True)
+    Fields (spec 001-review-issue-standard-path; supersedes earlier R5 / creep K3-K4):
+    - reviewer_id: identity for run-marker grouping (default "claude").
+    - project_board_required: absence-of-board is blocker when True (default True).
+    - standard_path: operator override for the issue-authoring standard's location
+      (FR-002). Relative paths are resolved against ``projects_home`` at load
+      time; absolute paths are used as-is. ``None`` means fall through to env
+      var (highest precedence) → built-in default search.
+    - source_config_path: absolute path to the ``.devkit/config.yaml`` that
+      supplied this block. Used by the standard-path resolver to label the
+      source in error messages (FR-007). ``None`` when no config file existed.
     """
 
     reviewer_id: str = "claude"
     project_board_required: bool = True
+    standard_path: Path | None = None
+    source_config_path: Path | None = None
 
 
-def _validate_review_issue_block(raw: Any, source: Path) -> ReviewIssueConfig:
-    """Parse and validate the review_issue config block. Returns defaults if raw is None."""
+def _validate_review_issue_block(
+    raw: Any, source: Path, projects_home: Path
+) -> ReviewIssueConfig:
+    """Parse and validate the review_issue config block.
+
+    Returns defaults (with ``source_config_path=None``) if ``raw`` is None.
+    Relative ``standard_path`` values are resolved against ``projects_home``;
+    absolute paths are used as-is.
+    """
     if raw is None:
         return ReviewIssueConfig()
     if not isinstance(raw, dict):
@@ -211,15 +227,14 @@ def _validate_review_issue_block(raw: Any, source: Path) -> ReviewIssueConfig:
             f"value must be a mapping (got {type(raw).__name__})",
             "use YAML mapping syntax, e.g.\n    review_issue:\n      reviewer_id: claude",
         )
-    allowed = {"reviewer_id", "gate"}
+    allowed = {"reviewer_id", "gate", "standard_path"}
     for key in raw:
         if key not in allowed:
             _config_error(
                 f"review_issue.{key}",
                 source,
                 f"unknown field: {key!r}",
-                f"remove the field. Allowed: {sorted(allowed)} "
-                "(see research.md R5 / creep.md K3/K4)",
+                f"remove the field. Allowed: {sorted(allowed)}",
             )
     reviewer_id = raw.get("reviewer_id", "claude")
     if not isinstance(reviewer_id, str) or not _REVIEWER_ID_RE.match(reviewer_id):
@@ -255,9 +270,26 @@ def _validate_review_issue_block(raw: Any, source: Path) -> ReviewIssueConfig:
             f"value must be a boolean (got {type(project_board_required).__name__})",
             "use 'true' or 'false'",
         )
+    standard_path: Path | None = None
+    raw_standard_path = raw.get("standard_path")
+    if raw_standard_path is not None:
+        if not isinstance(raw_standard_path, str) or not raw_standard_path.strip():
+            _config_error(
+                "review_issue.standard_path",
+                source,
+                f"value must be a non-empty string (got {type(raw_standard_path).__name__})",
+                "use a filesystem path, e.g.\n    review_issue:\n"
+                "      standard_path: appire_docs/docs/engineering/standards/issue_authoring.md",
+            )
+        sp = Path(raw_standard_path)
+        if not sp.is_absolute():
+            sp = (projects_home / sp).resolve()
+        standard_path = sp
     return ReviewIssueConfig(
         reviewer_id=reviewer_id,
         project_board_required=project_board_required,
+        standard_path=standard_path,
+        source_config_path=source,
     )
 
 
@@ -266,13 +298,16 @@ def load_review_issue_config(projects_home: Path) -> ReviewIssueConfig:
 
     Reads only the projects-home tier (matches `load_merged_config`'s primary
     source). Returns defaults if the block is absent. Raises `typer.Exit(70)`
-    via `_config_error` on schema failure.
+    via `_config_error` on schema failure. Threads ``projects_home`` into the
+    validator so relative ``standard_path`` values can be resolved against it.
     """
     projects_home_config = projects_home / DEVKIT_DIRNAME / CONFIG_FILENAME
     if not projects_home_config.is_file():
         return ReviewIssueConfig()
     data = _load_yaml(projects_home_config)
-    return _validate_review_issue_block(data.get("review_issue"), projects_home_config)
+    return _validate_review_issue_block(
+        data.get("review_issue"), projects_home_config, projects_home
+    )
 
 
 def _check_unknown_fields(data: dict[str, Any], allowed: set[str], source: Path) -> None:

--- a/src/aidevkit/review_issue.py
+++ b/src/aidevkit/review_issue.py
@@ -26,6 +26,7 @@ import re
 import sys
 import tempfile
 from dataclasses import dataclass
+from enum import StrEnum
 from importlib.resources import files as _resource_files
 from pathlib import Path
 from typing import Any
@@ -68,6 +69,19 @@ _ANTIPATTERN_CATEGORIES = frozenset(
 )
 
 
+class StandardPathSource(StrEnum):
+    """Identifies which precedence source supplied the resolved standard path.
+
+    Returned by ``_resolve_issue_authoring_standard_path`` and embedded in
+    failure error messages so operators know which surface to fix
+    (spec FR-007, contracts/error-format.md).
+    """
+
+    ENV_VAR = "environment variable DEVKIT_REVIEW_ISSUE_STANDARD_PATH"
+    CONFIG = "config field review_issue.standard_path"
+    DEFAULT = "built-in default (no env var or review_issue.standard_path configured)"
+
+
 @dataclass(frozen=True)
 class ReviewConfig:
     """Resolved per-invocation review configuration.
@@ -103,12 +117,16 @@ _OUTPUT_SCHEMA = _load_schema("review-issue-output.schema.json")
 # --------------------------------------------------------------------------- #
 
 
-def _resolve_review_config(reviewer_id_override: str | None) -> ReviewConfig:
+def _resolve_review_config(
+    reviewer_id_override: str | None,
+) -> tuple[ReviewConfig, ReviewIssueConfig]:
     """Resolve the review config from .devkit/config.yaml + CLI override.
 
-    Priority for reviewer_id (research R4): CLI flag > config > default "claude".
-    Falls back to defaults when projects-home isn't resolvable (e.g., running
-    outside any DevKit workspace).
+    Priority for reviewer_id: CLI flag > config > default "claude". Returns
+    BOTH the per-call ``ReviewConfig`` and the underlying persisted
+    ``ReviewIssueConfig``; the latter feeds the standard-path resolver
+    (spec 001-review-issue-standard-path FR-002). Falls back to defaults
+    when projects-home isn't resolvable.
     """
     persisted = ReviewIssueConfig()
     try:
@@ -116,43 +134,75 @@ def _resolve_review_config(reviewer_id_override: str | None) -> ReviewConfig:
         persisted = load_review_issue_config(projects_home)
     except typer.Exit:
         # No projects-home config — defaults apply. The standard-path resolver
-        # (T010) will surface a clearer error if the operator is genuinely in
-        # the wrong context.
+        # will surface a clearer error if the operator is genuinely in the
+        # wrong context.
         pass
-    return ReviewConfig(
+    config = ReviewConfig(
         reviewer_id=reviewer_id_override or persisted.reviewer_id,
         project_board_required=persisted.project_board_required,
     )
+    return config, persisted
 
 
-def _resolve_product_request_standard_path() -> Path:
-    """Locate the product-request standard.
+_STANDARD_REL_PATH = "appire_docs/docs/engineering/standards/issue_authoring.md"
 
-    Per research R10 / creep K3, the path is hardcoded — no config field.
-    Search order:
-      1. ``$DEVKIT_REVIEW_ISSUE_STANDARD_PATH`` env var (test hook only).
-      2. ``<cwd>/appire_docs/...`` — sibling repo in the workspace.
-      3. ``<cwd>/../appire_docs/...`` — sibling at the workspace root.
-    Fails with E_CONFIG_INVALID if none resolve.
+
+def _resolve_issue_authoring_standard_path(
+    config: ReviewIssueConfig,
+) -> tuple[Path, StandardPathSource]:
+    """Locate the App Empire issue-authoring standard for this invocation.
+
+    Strict precedence (spec FR-003): env var → config override → built-in
+    default. Once a higher-precedence source is set, lower-precedence sources
+    are NOT consulted even if the higher-precedence path does not resolve.
+    On failure, raises ``typer.Exit(E_CONFIG_INVALID)`` with an error message
+    that names BOTH the attempted path AND the source that supplied it
+    (FR-007; see contracts/error-format.md for the canonical format).
     """
-    rel = "appire_docs/docs/engineering/standards/product_requests.md"
     env_override = os.environ.get("DEVKIT_REVIEW_ISSUE_STANDARD_PATH")
     if env_override:
         candidate = Path(env_override)
         if candidate.is_file():
-            return candidate.resolve()
+            return candidate.resolve(), StandardPathSource.ENV_VAR
+        die(
+            "Issue-authoring standard not found.\n"
+            f"  Expected: {candidate}\n"
+            f"  Source:   {StandardPathSource.ENV_VAR.value}\n"
+            "  Fix:      unset DEVKIT_REVIEW_ISSUE_STANDARD_PATH or point it at "
+            "an existing file.",
+            code=E_CONFIG_INVALID,
+        )
+
+    if config.standard_path is not None:
+        candidate = config.standard_path
+        if candidate.is_file():
+            return candidate.resolve(), StandardPathSource.CONFIG
+        source_label = StandardPathSource.CONFIG.value
+        if config.source_config_path is not None:
+            source_label = f"{source_label} in {config.source_config_path}"
+        die(
+            "Issue-authoring standard not found.\n"
+            f"  Expected: {candidate}\n"
+            f"  Source:   {source_label}\n"
+            "  Fix:      correct the path in .devkit/config.yaml or remove "
+            "review_issue.standard_path to use the default.",
+            code=E_CONFIG_INVALID,
+        )
+
     cwd = Path.cwd()
     for base in (cwd, cwd.parent):
-        candidate = base / rel
+        candidate = base / _STANDARD_REL_PATH
         if candidate.is_file():
-            return candidate.resolve()
+            return candidate.resolve(), StandardPathSource.DEFAULT
     die(
-        f"product-request standard not found.\n"
-        f"  Expected: <workspace>/{rel}\n"
-        f"  Searched: {cwd / rel}\n"
-        f"           {cwd.parent / rel}\n"
-        f"  Likely cause: appire_docs is not checked out as a sibling repo in this workspace.\n"
-        f"  Fix: clone or worktree appire_docs alongside the repo you're reviewing from.",
+        "Issue-authoring standard not found.\n"
+        f"  Searched: {cwd / _STANDARD_REL_PATH}\n"
+        f"            {cwd.parent / _STANDARD_REL_PATH}\n"
+        f"  Source:   {StandardPathSource.DEFAULT.value}\n"
+        "  Likely cause: appire_docs is not checked out as a sibling repo in "
+        "this workspace.\n"
+        "  Fix:      clone or worktree appire_docs alongside this directory, "
+        "or set review_issue.standard_path in .devkit/config.yaml.",
         code=E_CONFIG_INVALID,
     )
     raise AssertionError("die() should have exited")  # pragma: no cover
@@ -462,8 +512,8 @@ def _now_iso() -> str:
 
 def cmd_review_issue_inspect(ref: str, reviewer_id: str | None) -> int:
     """Fetch issue + prior runs, emit JSON envelope to stdout."""
-    config = _resolve_review_config(reviewer_id)
-    _resolve_product_request_standard_path()  # fail-fast on missing standard
+    config, persisted = _resolve_review_config(reviewer_id)
+    _resolve_issue_authoring_standard_path(persisted)  # fail-fast on missing standard
     issue = _fetch_issue(ref)
     prior = _scan_prior_runs(issue.get("comments") or [])
     envelope = _build_inspect_envelope(issue, config, prior)
@@ -510,8 +560,8 @@ def cmd_review_issue_post(
             code=E_FINDINGS_INVALID,
         )
 
-    config = _resolve_review_config(reviewer_id)
-    _resolve_product_request_standard_path()  # fail-fast on missing standard
+    config, persisted = _resolve_review_config(reviewer_id)
+    _resolve_issue_authoring_standard_path(persisted)  # fail-fast on missing standard
     issue = _fetch_issue(ref)
     prior = _scan_prior_runs(issue.get("comments") or [])
     n = _next_n_for(prior, config.reviewer_id)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,7 +44,7 @@ EXPECTED_HELP = """\
 │ update        Upgrade DevKit to the latest release, then run doctor.         │
 │ check-update  Check whether a newer aidevkit release is available.           │
 │ version       Print the installed aidevkit version.                          │
-│ review-issue  Review a GitHub issue against the App Empire product-request   │
+│ review-issue  Review a GitHub issue against the App Empire issue-authoring   │
 │               standard.                                                      │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 """

--- a/tests/test_review_issue.py
+++ b/tests/test_review_issue.py
@@ -10,7 +10,7 @@ Helpers in this module:
   schema-validation tests.
 - ``cortex_expertise_issue_fixture``: the DevKit#17 motivating example
   (positive AC: env-var config; negative AC: does-not-require-cortex-config).
-- ``standard_path_env``: monkeypatch the product-request standard path so the
+- ``standard_path_env``: monkeypatch the issue-authoring standard path so the
   runtime existence check finds it during tests.
 """
 from __future__ import annotations
@@ -136,13 +136,13 @@ def cortex_pair_finding() -> dict[str, Any]:
 
 @pytest.fixture
 def standard_path_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Materialise a stub product-request standard and point the resolver at it.
+    """Materialise a stub issue-authoring standard and point the resolver at it.
 
     The resolver checks ``$DEVKIT_REVIEW_ISSUE_STANDARD_PATH`` first; setting
     that lets tests run from any cwd without dragging in the real appire_docs.
     """
-    standard = tmp_path / "product_requests.md"
-    standard.write_text("# Product Requests\nStub for tests.\n")
+    standard = tmp_path / "issue_authoring.md"
+    standard.write_text("# Issue Authoring\nStub for tests.\n")
     monkeypatch.setenv("DEVKIT_REVIEW_ISSUE_STANDARD_PATH", str(standard))
     return standard
 

--- a/tests/unit/test_config_review_issue.py
+++ b/tests/unit/test_config_review_issue.py
@@ -1,0 +1,155 @@
+"""Unit tests for the `review_issue` block in `.devkit/config.yaml`.
+
+Covers spec 001-review-issue-standard-path (DevKit#52) FR-002, FR-004, FR-006:
+the new optional ``standard_path`` field, its absence semantics, validation
+rules, and the relative-vs-absolute path resolution against ``projects_home``.
+
+Hermetic: writes throwaway YAML into tmp_path and invokes
+``load_review_issue_config`` directly. No real `.devkit/` lookup; no real
+filesystem state outside tmp_path is touched.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import typer
+
+from aidevkit.config import ReviewIssueConfig, load_review_issue_config
+
+
+def _write_config(projects_home: Path, body: str) -> Path:
+    devkit = projects_home / ".devkit"
+    devkit.mkdir(parents=True, exist_ok=True)
+    config = devkit / "config.yaml"
+    config.write_text(body)
+    return config
+
+
+# --------------------------------------------------------------------------- #
+# T015: field absent → standard_path is None
+# --------------------------------------------------------------------------- #
+
+
+def test_standard_path_field_absent_yields_none(tmp_path: Path) -> None:
+    """No `standard_path` in YAML → ReviewIssueConfig.standard_path is None."""
+    _write_config(
+        tmp_path,
+        "version: 1\norg: TestOrg\nworkspaces_home: /tmp\nreview_issue:\n  reviewer_id: claude\n",
+    )
+    cfg = load_review_issue_config(tmp_path)
+    assert cfg.standard_path is None
+
+
+def test_review_issue_block_entirely_absent_yields_defaults(tmp_path: Path) -> None:
+    """No `review_issue` block at all → all defaults; no errors."""
+    _write_config(
+        tmp_path,
+        "version: 1\norg: TestOrg\nworkspaces_home: /tmp\n",
+    )
+    cfg = load_review_issue_config(tmp_path)
+    assert cfg == ReviewIssueConfig()
+
+
+# --------------------------------------------------------------------------- #
+# T016: absolute path used as-is
+# --------------------------------------------------------------------------- #
+
+
+def test_standard_path_absolute_used_as_is(tmp_path: Path) -> None:
+    target = tmp_path / "abs.md"
+    target.write_text("# abs\n")
+    _write_config(
+        tmp_path,
+        "version: 1\norg: TestOrg\nworkspaces_home: /tmp\nreview_issue:\n"
+        f"  standard_path: {target}\n",
+    )
+    cfg = load_review_issue_config(tmp_path)
+    assert cfg.standard_path == target
+
+
+# --------------------------------------------------------------------------- #
+# T017: relative path resolved against projects_home
+# --------------------------------------------------------------------------- #
+
+
+def test_standard_path_relative_resolved_against_projects_home(tmp_path: Path) -> None:
+    """Relative `standard_path` MUST resolve against projects_home, not cwd."""
+    sub = tmp_path / "appire_docs" / "docs" / "engineering" / "standards"
+    sub.mkdir(parents=True)
+    (sub / "issue_authoring.md").write_text("# rel\n")
+    _write_config(
+        tmp_path,
+        "version: 1\norg: TestOrg\nworkspaces_home: /tmp\nreview_issue:\n"
+        "  standard_path: appire_docs/docs/engineering/standards/issue_authoring.md\n",
+    )
+    cfg = load_review_issue_config(tmp_path)
+    assert cfg.standard_path == (sub / "issue_authoring.md").resolve()
+
+
+# --------------------------------------------------------------------------- #
+# T018–T019: invalid values
+# --------------------------------------------------------------------------- #
+
+
+def test_standard_path_non_string_rejected(tmp_path: Path) -> None:
+    _write_config(
+        tmp_path,
+        "version: 1\norg: TestOrg\nworkspaces_home: /tmp\nreview_issue:\n  standard_path: 42\n",
+    )
+    with pytest.raises(typer.Exit) as excinfo:
+        load_review_issue_config(tmp_path)
+    assert excinfo.value.exit_code == 70  # E_CONFIG_INVALID
+
+
+def test_standard_path_empty_string_rejected(tmp_path: Path) -> None:
+    _write_config(
+        tmp_path,
+        "version: 1\norg: TestOrg\nworkspaces_home: /tmp\nreview_issue:\n  standard_path: \"\"\n",
+    )
+    with pytest.raises(typer.Exit) as excinfo:
+        load_review_issue_config(tmp_path)
+    assert excinfo.value.exit_code == 70
+
+
+def test_standard_path_mapping_rejected(tmp_path: Path) -> None:
+    """V5: a mapping value is rejected (must be a string)."""
+    _write_config(
+        tmp_path,
+        "version: 1\norg: TestOrg\nworkspaces_home: /tmp\nreview_issue:\n"
+        "  standard_path:\n    nested: oops\n",
+    )
+    with pytest.raises(typer.Exit) as excinfo:
+        load_review_issue_config(tmp_path)
+    assert excinfo.value.exit_code == 70
+
+
+# --------------------------------------------------------------------------- #
+# Co-existence with sibling fields
+# --------------------------------------------------------------------------- #
+
+
+def test_standard_path_coexists_with_reviewer_id_and_gate(tmp_path: Path) -> None:
+    target = tmp_path / "co.md"
+    target.write_text("# co\n")
+    _write_config(
+        tmp_path,
+        "version: 1\norg: TestOrg\nworkspaces_home: /tmp\nreview_issue:\n"
+        "  reviewer_id: gpt\n"
+        f"  standard_path: {target}\n"
+        "  gate:\n    project_board_required: false\n",
+    )
+    cfg = load_review_issue_config(tmp_path)
+    assert cfg.reviewer_id == "gpt"
+    assert cfg.project_board_required is False
+    assert cfg.standard_path == target
+
+
+def test_source_config_path_populated_when_block_present(tmp_path: Path) -> None:
+    """Source path is stamped on the dataclass so the resolver can label errors."""
+    cfg_file = _write_config(
+        tmp_path,
+        "version: 1\norg: TestOrg\nworkspaces_home: /tmp\nreview_issue:\n  reviewer_id: claude\n",
+    )
+    cfg = load_review_issue_config(tmp_path)
+    assert cfg.source_config_path == cfg_file

--- a/tests/unit/test_review_issue_resolver.py
+++ b/tests/unit/test_review_issue_resolver.py
@@ -1,0 +1,348 @@
+"""Unit tests for the issue-authoring standard-path resolver.
+
+Covers spec 001-review-issue-standard-path (DevKit#52):
+- FR-001: default-location resolution at the new path.
+- FR-003: strict env-var / config precedence (no fallback after a higher source is set).
+- FR-005: single-resolution invariant per CLI invocation.
+- FR-006: relative + absolute override path handling.
+- FR-007: failure messages name both the attempted path AND the source.
+- SC-005: existing env-var test hook continues to work post-rename.
+
+Hermetic: pytest's `monkeypatch.chdir` / `monkeypatch.setenv` keep these tests
+isolated from real filesystem state. The autouse `_clear_resolver_env` fixture
+guarantees a clean env-var baseline.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+import pytest
+import typer
+
+from aidevkit import review_issue
+from aidevkit.config import ReviewIssueConfig
+from aidevkit.review_issue import (
+    StandardPathSource,
+    _resolve_issue_authoring_standard_path,
+)
+from aidevkit.util import E_CONFIG_INVALID
+
+REL = "appire_docs/docs/engineering/standards/issue_authoring.md"
+
+
+def _make_default_standard(base: Path) -> Path:
+    """Materialise the standard at the canonical default sub-path under ``base``."""
+    standard = base / REL
+    standard.parent.mkdir(parents=True, exist_ok=True)
+    standard.write_text("# Issue Authoring (stub)\n")
+    return standard
+
+
+@pytest.fixture(autouse=True)
+def _clear_resolver_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure the resolver's env-var hook is unset by default for each test."""
+    monkeypatch.delenv("DEVKIT_REVIEW_ISSUE_STANDARD_PATH", raising=False)
+
+
+# --------------------------------------------------------------------------- #
+# T005–T008: US1 default-search behavior + env-var backward compat
+# --------------------------------------------------------------------------- #
+
+
+def test_default_search_finds_at_cwd_appire_docs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Default resolver hits ``<cwd>/appire_docs/.../issue_authoring.md`` (FR-001)."""
+    standard = _make_default_standard(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    path, source = _resolve_issue_authoring_standard_path(ReviewIssueConfig())
+    assert path == standard.resolve()
+    assert source is StandardPathSource.DEFAULT
+
+
+def test_default_search_falls_back_to_cwd_parent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When cwd has no standard, resolver searches ``<cwd>/..`` next."""
+    standard = _make_default_standard(tmp_path)
+    nested = tmp_path / "subdir"
+    nested.mkdir()
+    monkeypatch.chdir(nested)
+    path, source = _resolve_issue_authoring_standard_path(ReviewIssueConfig())
+    assert path == standard.resolve()
+    assert source is StandardPathSource.DEFAULT
+
+
+def test_default_search_both_missing_raises_with_default_source_label(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Both default locations absent → typer.Exit + source label + both paths in err."""
+    nested = tmp_path / "deep" / "nested"
+    nested.mkdir(parents=True)
+    monkeypatch.chdir(nested)
+    with pytest.raises(typer.Exit) as excinfo:
+        _resolve_issue_authoring_standard_path(ReviewIssueConfig())
+    assert excinfo.value.exit_code == E_CONFIG_INVALID
+    err = capsys.readouterr().err
+    assert "Issue-authoring standard not found" in err
+    assert StandardPathSource.DEFAULT.value in err
+    assert str(nested / REL) in err
+    assert str(nested.parent / REL) in err
+
+
+def test_env_var_hook_still_works_post_rename(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SC-005: existing env-var test hook continues to work after the rename."""
+    standard = tmp_path / "anywhere.md"
+    standard.write_text("# Stub\n")
+    monkeypatch.setenv("DEVKIT_REVIEW_ISSUE_STANDARD_PATH", str(standard))
+    monkeypatch.chdir(tmp_path)
+    path, source = _resolve_issue_authoring_standard_path(ReviewIssueConfig())
+    assert path == standard.resolve()
+    assert source is StandardPathSource.ENV_VAR
+
+
+# --------------------------------------------------------------------------- #
+# T020–T021: US2 config-override happy path + (US3 flips T021 → strict)
+# --------------------------------------------------------------------------- #
+
+
+def test_resolver_uses_config_override_when_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """FR-002: config.standard_path is honored when it points at an existing file."""
+    override = tmp_path / "custom-standard.md"
+    override.write_text("# Custom\n")
+    config = ReviewIssueConfig(
+        standard_path=override, source_config_path=tmp_path / "config.yaml"
+    )
+    monkeypatch.chdir(tmp_path)
+    path, source = _resolve_issue_authoring_standard_path(config)
+    assert path == override.resolve()
+    assert source is StandardPathSource.CONFIG
+
+
+# --------------------------------------------------------------------------- #
+# T027–T030: US3 strict precedence + source labels
+# --------------------------------------------------------------------------- #
+
+
+def test_env_var_strict_precedence_missing_file_raises(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """FR-003: env-var path missing → command fails, does NOT fall back (R1)."""
+    # Set up a valid default standard so we can prove it's NOT consulted.
+    _make_default_standard(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    bogus = tmp_path / "does_not_exist.md"
+    monkeypatch.setenv("DEVKIT_REVIEW_ISSUE_STANDARD_PATH", str(bogus))
+    with pytest.raises(typer.Exit) as excinfo:
+        _resolve_issue_authoring_standard_path(ReviewIssueConfig())
+    assert excinfo.value.exit_code == E_CONFIG_INVALID
+    err = capsys.readouterr().err
+    assert str(bogus) in err
+    assert StandardPathSource.ENV_VAR.value in err
+    # Strict precedence: the default-source label MUST NOT appear (no fallback).
+    assert StandardPathSource.DEFAULT.value not in err
+
+
+def test_config_strict_precedence_missing_file_raises(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Config-path missing → command fails with config source label, no fallback."""
+    # Default standard exists to prove it's NOT consulted (strict).
+    _make_default_standard(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    bogus = tmp_path / "missing-override.md"
+    config_file = tmp_path / "fake-config.yaml"
+    config_file.write_text("review_issue:\n  standard_path: missing-override.md\n")
+    config = ReviewIssueConfig(standard_path=bogus, source_config_path=config_file)
+    with pytest.raises(typer.Exit) as excinfo:
+        _resolve_issue_authoring_standard_path(config)
+    assert excinfo.value.exit_code == E_CONFIG_INVALID
+    err = capsys.readouterr().err
+    assert str(bogus) in err
+    assert "config field review_issue.standard_path" in err
+    assert str(config_file) in err  # source path is named in the label
+    assert StandardPathSource.DEFAULT.value not in err  # no fallback
+
+
+def test_config_strict_precedence_no_fallback_to_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """T030 (replaces the earlier chain-fallback expectation): config-missing must
+    NOT silently fall through to the default search, even when default exists."""
+    _make_default_standard(tmp_path)  # default IS present
+    monkeypatch.chdir(tmp_path)
+    config = ReviewIssueConfig(
+        standard_path=tmp_path / "nope.md", source_config_path=tmp_path / "c.yaml"
+    )
+    with pytest.raises(typer.Exit):
+        _resolve_issue_authoring_standard_path(config)
+    # The command failed at the config-source level — that's the strict-
+    # precedence contract. Default was never consulted.
+    assert StandardPathSource.DEFAULT.value not in capsys.readouterr().err
+
+
+def test_default_search_error_includes_source_label(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Default-search failure includes the DEFAULT source label."""
+    nested = tmp_path / "nowhere" / "deeper"
+    nested.mkdir(parents=True)
+    monkeypatch.chdir(nested)
+    with pytest.raises(typer.Exit):
+        _resolve_issue_authoring_standard_path(ReviewIssueConfig())
+    err = capsys.readouterr().err
+    assert StandardPathSource.DEFAULT.value in err
+    # Both attempted paths are listed
+    assert str(nested / REL) in err
+    assert str(nested.parent / REL) in err
+
+
+def test_resolver_returns_path_and_source_tuple(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The resolver always returns (Path, StandardPathSource) on success."""
+    # Branch A: env var
+    env_target = tmp_path / "env.md"
+    env_target.write_text("# env\n")
+    monkeypatch.setenv("DEVKIT_REVIEW_ISSUE_STANDARD_PATH", str(env_target))
+    result = _resolve_issue_authoring_standard_path(ReviewIssueConfig())
+    assert isinstance(result, tuple) and len(result) == 2
+    assert isinstance(result[0], Path)
+    assert isinstance(result[1], StandardPathSource)
+    monkeypatch.delenv("DEVKIT_REVIEW_ISSUE_STANDARD_PATH")
+
+    # Branch B: config
+    cfg_target = tmp_path / "cfg.md"
+    cfg_target.write_text("# cfg\n")
+    config = ReviewIssueConfig(
+        standard_path=cfg_target, source_config_path=tmp_path / "c.yaml"
+    )
+    result = _resolve_issue_authoring_standard_path(config)
+    assert result == (cfg_target.resolve(), StandardPathSource.CONFIG)
+
+    # Branch C: default
+    default_target = _make_default_standard(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    result = _resolve_issue_authoring_standard_path(ReviewIssueConfig())
+    assert result == (default_target.resolve(), StandardPathSource.DEFAULT)
+
+
+# --------------------------------------------------------------------------- #
+# T031b: FR-005 single-resolution invariant per CLI invocation
+# --------------------------------------------------------------------------- #
+
+
+def _patched_resolver_counter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Callable[[], int]:
+    """Wrap _resolve_issue_authoring_standard_path with a call counter."""
+    original = review_issue._resolve_issue_authoring_standard_path
+    call_count = {"n": 0}
+
+    def _wrapper(config: ReviewIssueConfig):
+        call_count["n"] += 1
+        return original(config)
+
+    monkeypatch.setattr(
+        review_issue,
+        "_resolve_issue_authoring_standard_path",
+        _wrapper,
+    )
+    return lambda: call_count["n"]
+
+
+def test_resolver_invoked_exactly_once_per_inspect_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    subprocess_capture,  # noqa: ANN001 — fixture from top-level conftest
+) -> None:
+    """FR-005: a single `inspect` invocation MUST resolve the standard exactly once."""
+    # Stub the standard via env var (cheap, hermetic).
+    standard = tmp_path / "issue_authoring.md"
+    standard.write_text("# stub\n")
+    monkeypatch.setenv("DEVKIT_REVIEW_ISSUE_STANDARD_PATH", str(standard))
+
+    # Mock gh issue view to return a minimal valid envelope.
+    import json as _json
+
+    from aidevkit.util import RunResult
+
+    issue = {
+        "number": 1,
+        "url": "https://github.com/o/r/issues/1",
+        "title": "T",
+        "body": "## Summary\nx\n",
+        "labels": [],
+        "assignees": [],
+        "milestone": None,
+        "projectItems": [],
+        "comments": [],
+    }
+    subprocess_capture.set_default(
+        RunResult(code=0, stdout=_json.dumps(issue), stderr="")
+    )
+
+    get_count = _patched_resolver_counter(monkeypatch)
+    review_issue.cmd_review_issue_inspect("o/r#1", reviewer_id=None)
+    assert get_count() == 1
+
+
+def test_resolver_invoked_exactly_once_per_post_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    subprocess_capture,  # noqa: ANN001
+) -> None:
+    """FR-005: a single `post` invocation MUST resolve the standard exactly once."""
+    import io
+    import json as _json
+
+    from aidevkit.util import RunResult
+
+    standard = tmp_path / "issue_authoring.md"
+    standard.write_text("# stub\n")
+    monkeypatch.setenv("DEVKIT_REVIEW_ISSUE_STANDARD_PATH", str(standard))
+
+    issue = {
+        "number": 1,
+        "url": "https://github.com/o/r/issues/1",
+        "title": "T",
+        "body": "## Summary\nx\n",
+        "labels": [],
+        "assignees": [],
+        "milestone": None,
+        "projectItems": [],
+        "comments": [],
+    }
+    subprocess_capture.set_default(
+        RunResult(code=0, stdout=_json.dumps(issue), stderr="")
+    )
+    monkeypatch.setattr(
+        "sys.stdin",
+        io.StringIO(_json.dumps({"schema_version": "1", "findings": []})),
+    )
+
+    get_count = _patched_resolver_counter(monkeypatch)
+    review_issue.cmd_review_issue_post(
+        "o/r#1",
+        reviewer_id=None,
+        dry_run=True,
+        json_output=False,
+        verbose=False,
+        min_severity="warning",
+    )
+    assert get_count() == 1

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "aidevkit"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
## Summary

Closes #52.

Un-breaks `/devkit.review-issue` after `appire_docs` renamed `product_requests.md` → `issue_authoring.md` (commit `cd93823`), and adds an operator-configurable override so future renames don't require a coordinated DevKit release.

## What changed

**Resolver** (`src/aidevkit/review_issue.py`)
- `_resolve_product_request_standard_path` → `_resolve_issue_authoring_standard_path`. New signature `(ReviewIssueConfig) -> (Path, StandardPathSource)`.
- **Strict precedence**: env var → config override → built-in 2-location default search. Once a higher-precedence source is set, lower sources are not consulted, even on file-not-found.
- Failure errors name **both the attempted path AND the source** that supplied it — operators know which surface to fix without reading source code.
- New `StandardPathSource` enum carries the canonical source-label strings.

**Config schema** (`src/aidevkit/config.py`)
- `ReviewIssueConfig` gains two fields:
  - `standard_path: Path | None` — operator override (new).
  - `source_config_path: Path | None` — the `.devkit/config.yaml` that supplied this block; used by the resolver for source labeling on failure.
- `_validate_review_issue_block` now takes `projects_home`, adds `standard_path` to the allow-list, validates non-empty string, rejects mappings/sequences/non-strings, and resolves relative paths against `projects_home`. Absolute paths used as-is.
- `load_review_issue_config` threads `projects_home` through.

**Operator-facing surfaces**
- `src/aidevkit/cli.py`: help text *"product-request"* → *"issue-authoring"*.
- `src/aidevkit/commands/devkit.review-issue.md`: 5 occurrences of `product_requests.md` → `issue_authoring.md`; the FR-006 lock-in note rewritten to describe the new precedence chain; the `E_CONFIG_INVALID` note enriched with the source-label contract.

**Release prep**
- `pyproject.toml` version 0.4.0 → 0.5.0 (minor — new config surface).

## Tests

Baseline: **310 passed**. After: **331 passed** (+21 new), lint clean.

- `tests/unit/test_review_issue_resolver.py` (NEW, 12 tests): default-search happy path + parent fallback (FR-001), env-var hook backward-compat (SC-005), env-var strict precedence + source label (FR-003 + FR-007), config strict precedence + source label, default-source label in error, tuple-return shape, FR-005 single-resolution invariant verified on both `inspect` and `post` via wrapper counter.
- `tests/unit/test_config_review_issue.py` (NEW, 9 tests): field-absent → None (FR-004), absolute used as-is + relative resolved against projects-home (FR-006), non-string/empty/mapping rejected, coexistence with `reviewer_id` + `gate.project_board_required`, `source_config_path` stamping.
- `tests/test_review_issue.py`: existing `standard_path_env` fixture renamed `product_requests.md` → `issue_authoring.md` (the fixture uses the env-var hook, so the filename change is cosmetic).
- `tests/test_cli.py`: help-snapshot updated for the rename.

## Smoke test (manual)

Ran the three quickstart scenarios against this branch:

```
Scenario A (default):         DEFAULT  → /Users/.../appire_docs/docs/engineering/standards/issue_authoring.md
Scenario B (config override): CONFIG   → /tmp/tmpwe6gtpe9.md
Scenario C (env-var missing): exit 70, error names path + "environment variable DEVKIT_REVIEW_ISSUE_STANDARD_PATH" source
```

All three behave per `contracts/error-format.md`.

## Notes

- `inspect` and `post` call sites updated to destructure the new resolver tuple; return values still discarded (fail-fast remains the resolver's purpose at command setup).
- `_resolve_review_config` now returns `(ReviewConfig, ReviewIssueConfig)` so the persisted config reaches the resolver. Only two callers in the same module, both updated.
- The env-var test hook `DEVKIT_REVIEW_ISSUE_STANDARD_PATH` is preserved unchanged — existing tests using it pass without modification (SC-005).

## Test plan

- [x] Unit tests added for FR-001..FR-007 and SC-005
- [x] Existing test suite still green (331 passed total)
- [x] Lint clean (`uv run ruff check src tests`)
- [x] Manual smoke for default + config-override + env-var-failure scenarios
- [ ] Reviewer: spot-check the slash-command markdown wording in `devkit.review-issue.md`
- [ ] Reviewer: sanity-check the resolver error messages match `contracts/error-format.md` (see local spec, not in PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)