### PR TITLE
feat: devkit refresh-issue-meta — re-fetch issue title/url into WORKSPACE.md

### DIFF
--- a/src/aidevkit/cli.py
+++ b/src/aidevkit/cli.py
@@ -14,6 +14,7 @@ from . import doctor as _doctor
 from . import pr_create as _pr_create
 from . import preflight as _preflight
 from . import purge as _purge
+from . import refresh_issue_meta as _refresh_issue_meta
 from . import review_issue as _review_issue
 from . import setup as _setup
 from . import status as _status
@@ -189,6 +190,14 @@ def archive(
 def preflight() -> None:
     code = _preflight.cmd_preflight()
     raise typer.Exit(code=code)
+
+
+@app.command(
+    "refresh-issue-meta",
+    help="Refresh issue_title / issue_url in WORKSPACE.md from the current GitHub issue state.",
+)
+def refresh_issue_meta() -> None:
+    _refresh_issue_meta.cmd_refresh_issue_meta()
 
 
 @app.command(help="Summarize every active per-issue workspace: issue state, branches, PRs.")

--- a/src/aidevkit/commands/devkit.refresh-issue-meta.md
+++ b/src/aidevkit/commands/devkit.refresh-issue-meta.md
@@ -1,0 +1,38 @@
+---
+description: Refresh issue_title / issue_url in WORKSPACE.md from the current GitHub issue state
+---
+
+# /devkit.refresh-issue-meta
+
+Re-fetch the GitHub issue's title and canonical URL and update `WORKSPACE.md` accordingly. Opt-in, scoped, diff-on-change, no-op-on-unchanged. Only `issue_title` and `issue_url` are ever touched — no other frontmatter field, no other file.
+
+## Usage
+
+Run from the per-issue workspace root (the directory containing `WORKSPACE.md`):
+
+    /devkit.refresh-issue-meta
+
+No arguments. The workspace's owning issue is read from `WORKSPACE.md` frontmatter (`issue_owner_repo` + `issue_number`).
+
+## What to do
+
+1. Confirm the current working directory is a per-issue workspace root (contains `WORKSPACE.md`). If not, surface the missing-precondition error to the user — do NOT attempt to walk upward or guess.
+
+2. Run the refresh command:
+
+       devkit refresh-issue-meta
+
+3. Interpret the outcome:
+   - **Exit 0, empty stdout**: workspace was already in sync. Tell the user nothing changed.
+   - **Exit 0, one or two `[devkit] refresh-issue-meta: ...` lines on stdout**: surface those diff lines verbatim. They describe exactly which field(s) updated.
+   - **Exit 20** (`WORKSPACE.md not found`): surface the error. The user is not in a workspace root.
+   - **Exit 16** (`WORKSPACE.md malformed`): surface the error including the named precondition (missing delimiter, missing field, etc.). Do NOT attempt to repair the file automatically.
+   - **Exit 12** (`gh CLI missing or unauthenticated`): surface the error. The user needs to install `gh` or run `gh auth login` — do not run those for them.
+   - **Exit 13** (`gh issue view failed`): surface the upstream `gh` stderr. The issue may have been deleted, made private, or the network is unreachable.
+   - **Exit 1** (concurrent modification): rare race where `WORKSPACE.md` was edited between read and write. Tell the user to re-run.
+
+## Notes
+
+- This command never modifies anything outside `WORKSPACE.md`. If a diff appears in any other file under the workspace after running it, that is a bug — surface it to the user.
+- This is **strictly opt-in**. Do not invoke it as part of any other slash command's workflow. It costs one GitHub API call per invocation.
+- `issue_owner_repo` and `issue_number` are authoritative for the lifetime of the workspace; this command never changes them, even if the issue was transferred between repos.

--- a/src/aidevkit/refresh_issue_meta.py
+++ b/src/aidevkit/refresh_issue_meta.py
@@ -1,0 +1,397 @@
+"""DevKit ``refresh-issue-meta`` subcommand.
+
+Refresh ``issue_title`` / ``issue_url`` in a per-issue workspace's
+``WORKSPACE.md`` from the current state of the GitHub issue. Opt-in,
+scoped, diff-on-change, no-op-on-unchanged — same shape as the rest of
+the ``refresh-*`` family (DevKit#37).
+
+Spec: ``specs/001-refresh-issue-meta/spec.md`` (DevKit#39).
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+import typer
+import yaml
+
+from .util import (
+    E_DEP_MISSING,
+    E_NOT_IN_WORKSPACE,
+    E_REPO_NOT_FOUND,
+    E_WORKSPACE_MISSING,
+    die,
+    gh,
+    info,
+)
+
+WORKSPACE_FILENAME: Final = "WORKSPACE.md"
+_FRONTMATTER_DELIM = "---\n"
+
+
+class NotInWorkspaceError(Exception):
+    """``WORKSPACE.md`` is not present in the target directory."""
+
+
+class WorkspaceMalformedError(Exception):
+    """``WORKSPACE.md`` exists but its frontmatter is missing/unparseable/incomplete."""
+
+
+class GhMissingError(Exception):
+    """The ``gh`` CLI is absent or unauthenticated."""
+
+
+class IssueFetchError(Exception):
+    """``gh issue view`` returned a non-zero exit or unexpected JSON."""
+
+
+class ConcurrentModificationError(Exception):
+    """``WORKSPACE.md`` was modified by another writer between our read and write."""
+
+
+@dataclass
+class RefreshResult:
+    """Outcome of a single ``refresh()`` invocation.
+
+    ``title_changed`` / ``url_changed`` indicate which fields the on-disk
+    file required updating. The ``old_*`` values are what was on disk
+    before the refresh; ``new_*`` are what is on disk after (== ``old_*``
+    when that field did not change).
+    """
+
+    title_changed: bool
+    url_changed: bool
+    old_title: str
+    new_title: str
+    old_url: str
+    new_url: str
+
+    @property
+    def any_changed(self) -> bool:
+        return self.title_changed or self.url_changed
+
+
+def _find_frontmatter_slice(text: str) -> tuple[str, str, str]:
+    """Locate the YAML frontmatter block.
+
+    Returns ``(prefix, frontmatter_body, suffix)`` where
+    ``prefix + frontmatter_body + suffix == text`` exactly and
+    ``frontmatter_body`` contains the lines between (and excluding) the
+    opening ``---`` and closing ``---`` delimiters.
+
+    Raises ``WorkspaceMalformedError`` if either delimiter is missing.
+    """
+    if not text.startswith(_FRONTMATTER_DELIM):
+        raise WorkspaceMalformedError(
+            "WORKSPACE.md is malformed: missing opening '---' frontmatter delimiter"
+        )
+
+    # Find the closing delimiter. Search starts after the first delimiter.
+    after_open = len(_FRONTMATTER_DELIM)
+    close_idx = text.find("\n" + _FRONTMATTER_DELIM, after_open - 1)
+    if close_idx == -1:
+        # Also accept an EOF-anchored closing form for the (unusual) bodyless case.
+        if text.endswith("\n" + _FRONTMATTER_DELIM.rstrip()):
+            close_idx = len(text) - len(_FRONTMATTER_DELIM.rstrip()) - 1
+        else:
+            raise WorkspaceMalformedError(
+                "WORKSPACE.md is malformed: missing closing '---' frontmatter delimiter"
+            )
+
+    prefix = text[:after_open]
+    frontmatter_body = text[after_open : close_idx + 1]
+    suffix = text[close_idx + 1 :]
+    return prefix, frontmatter_body, suffix
+
+
+def _parse_workspace_md(workspace_md_text: str) -> tuple[str, int, str, str]:
+    """Read the four fields this command cares about.
+
+    Returns ``(issue_owner_repo, issue_number, issue_title, issue_url)``.
+    Raises ``WorkspaceMalformedError`` with a message naming the specific
+    issue if any field is missing, wrong-typed, or unparseable.
+    """
+    _, frontmatter_body, _ = _find_frontmatter_slice(workspace_md_text)
+    try:
+        data = yaml.safe_load(frontmatter_body)
+    except yaml.YAMLError as exc:
+        raise WorkspaceMalformedError(
+            f"WORKSPACE.md frontmatter does not parse as YAML: {exc}"
+        ) from exc
+
+    if not isinstance(data, dict):
+        raise WorkspaceMalformedError(
+            "WORKSPACE.md frontmatter does not parse as a YAML mapping"
+        )
+
+    owner_repo = data.get("issue_owner_repo")
+    if not isinstance(owner_repo, str) or not re.fullmatch(r"[^/\s]+/[^/\s]+", owner_repo):
+        raise WorkspaceMalformedError(
+            "WORKSPACE.md frontmatter field 'issue_owner_repo' is missing "
+            "or not in 'owner/repo' form"
+        )
+
+    number_raw = data.get("issue_number")
+    if isinstance(number_raw, bool) or not isinstance(number_raw, int) or number_raw <= 0:
+        raise WorkspaceMalformedError(
+            "WORKSPACE.md frontmatter field 'issue_number' is missing or not a positive integer"
+        )
+
+    title = data.get("issue_title")
+    if not isinstance(title, str):
+        raise WorkspaceMalformedError(
+            "WORKSPACE.md frontmatter field 'issue_title' is missing or not a string"
+        )
+
+    url = data.get("issue_url")
+    if not isinstance(url, str):
+        raise WorkspaceMalformedError(
+            "WORKSPACE.md frontmatter field 'issue_url' is missing or not a string"
+        )
+
+    return owner_repo, number_raw, title, url
+
+
+def _fetch_issue_meta(owner_repo: str, number: int) -> tuple[str, str]:
+    """Fetch the current title and canonical URL via ``gh issue view``.
+
+    Returns ``(title, url)``. Raises ``GhMissingError`` if the ``gh`` binary
+    is absent / unauthenticated, ``IssueFetchError`` for any other failure.
+    """
+    try:
+        result = gh(
+            "issue", "view", str(number),
+            "--repo", owner_repo,
+            "--json", "title,url",
+        )
+    except FileNotFoundError as exc:
+        raise GhMissingError(
+            "gh CLI not found on PATH — install GitHub CLI and run `gh auth login`"
+        ) from exc
+
+    if result.code != 0:
+        stderr_lower = (result.stderr or "").lower()
+        if (
+            "not logged" in stderr_lower
+            or "not authenticated" in stderr_lower
+            or "authentication" in stderr_lower
+            or "gh auth login" in stderr_lower
+            or "ghp_" in stderr_lower
+        ):
+            raise GhMissingError(
+                f"gh CLI is not authenticated for {owner_repo} — run `gh auth login`\n"
+                f"  {result.stderr.strip()}"
+            )
+        raise IssueFetchError(
+            f"gh issue view failed for {owner_repo}#{number} (exit {result.code})\n"
+            f"  {result.stderr.strip()}"
+        )
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise IssueFetchError(
+            f"gh issue view returned unparseable JSON for {owner_repo}#{number}: {exc}"
+        ) from exc
+
+    title = payload.get("title")
+    url = payload.get("url")
+    if not isinstance(title, str) or not isinstance(url, str):
+        raise IssueFetchError(
+            f"gh issue view JSON missing expected fields for {owner_repo}#{number}: {payload!r}"
+        )
+    return title, url
+
+
+def _encode_field_value(field: str, value: str) -> str:
+    """Render a single ``key: value`` line in the canonical on-disk form.
+
+    Uses the same ``yaml.safe_dump`` settings as bootstrap stamping (no
+    flow style, no unicode passthrough) so values round-trip stably.
+    The trailing newline is stripped.
+    """
+    encoded = yaml.safe_dump(
+        {field: value},
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=False,
+    )
+    return encoded.rstrip("\n")
+
+
+def _substitute_field_line(frontmatter_body: str, field: str, new_value: str) -> str:
+    """Replace the line ``{field}: ...`` inside the frontmatter body.
+
+    Anchored to start-of-line; matches exactly the field's existing line.
+    Raises ``RuntimeError`` if zero matches found (caller should have
+    validated the field exists via ``_parse_workspace_md`` first).
+    """
+    new_line = _encode_field_value(field, new_value)
+    pattern = re.compile(rf"^{re.escape(field)}:.*$", re.MULTILINE)
+    updated, count = pattern.subn(new_line, frontmatter_body, count=1)
+    if count == 0:
+        raise RuntimeError(
+            f"internal: field {field!r} not found in frontmatter body during substitution"
+        )
+    return updated
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    """Write ``content`` to ``path`` atomically (tempfile in same dir + rename)."""
+    fd, tmp_path_str = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    tmp_path = Path(tmp_path_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(content)
+        os.replace(tmp_path, path)
+    except Exception:
+        # Best-effort cleanup; ignore failures.
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def refresh(workspace_root: Path) -> RefreshResult:
+    """Refresh ``issue_title`` / ``issue_url`` in ``<workspace_root>/WORKSPACE.md``.
+
+    Returns a ``RefreshResult`` describing what (if anything) changed.
+    Raises ``NotInWorkspaceError``, ``WorkspaceMalformedError``,
+    ``GhMissingError``, ``IssueFetchError``, or
+    ``ConcurrentModificationError`` on the respective failure modes.
+
+    Does NOT print to stdout; the Typer wrapper ``run_command`` owns
+    user-facing output.
+    """
+    workspace_md = workspace_root / WORKSPACE_FILENAME
+    if not workspace_md.is_file():
+        raise NotInWorkspaceError(
+            f"WORKSPACE.md not found in {workspace_root} — run from a per-issue workspace root"
+        )
+
+    initial_mtime_ns = workspace_md.stat().st_mtime_ns
+    original_text = workspace_md.read_text(encoding="utf-8")
+    owner_repo, number, disk_title, disk_url = _parse_workspace_md(original_text)
+
+    fetched_title, fetched_url = _fetch_issue_meta(owner_repo, number)
+
+    title_changed = disk_title != fetched_title
+    url_changed = disk_url != fetched_url
+
+    if not title_changed and not url_changed:
+        return RefreshResult(
+            title_changed=False,
+            url_changed=False,
+            old_title=disk_title,
+            new_title=disk_title,
+            old_url=disk_url,
+            new_url=disk_url,
+        )
+
+    prefix, frontmatter_body, suffix = _find_frontmatter_slice(original_text)
+    if title_changed:
+        frontmatter_body = _substitute_field_line(
+            frontmatter_body, "issue_title", fetched_title
+        )
+    if url_changed:
+        frontmatter_body = _substitute_field_line(
+            frontmatter_body, "issue_url", fetched_url
+        )
+    new_text = prefix + frontmatter_body + suffix
+
+    # Concurrent-modification guard (research §R6): mtime must not have
+    # advanced between our read and our write. Belt-and-suspenders for the
+    # rare developer-editor-vs-CLI race.
+    current_mtime_ns = workspace_md.stat().st_mtime_ns
+    if current_mtime_ns != initial_mtime_ns:
+        raise ConcurrentModificationError(
+            "WORKSPACE.md was changed during refresh (mtime moved) — re-run"
+        )
+
+    _atomic_write_text(workspace_md, new_text)
+
+    return RefreshResult(
+        title_changed=title_changed,
+        url_changed=url_changed,
+        old_title=disk_title,
+        new_title=fetched_title if title_changed else disk_title,
+        old_url=disk_url,
+        new_url=fetched_url if url_changed else disk_url,
+    )
+
+
+def _diff_line(field: str, old: str, new: str, *, max_cols: int = 120) -> str:
+    """Format a single diff line, eliding long values to fit ``max_cols`` columns.
+
+    Layout: ``refresh-issue-meta: {field} {old!r} → {new!r}``. After
+    ``info()`` prefixes ``[devkit] ``, the total target width is
+    ``max_cols``. If either repr is long enough to overflow, the value is
+    middle-elided with ``…``.
+    """
+    prefix_overhead = len("[devkit] refresh-issue-meta: ")
+    field_part = f"{field} "
+    arrow = " → "
+    fixed_overhead = prefix_overhead + len(field_part) + len(arrow)
+
+    budget_for_values = max_cols - fixed_overhead
+    if budget_for_values < 8:
+        # Pathological narrow terminal — give up on elision; let it wrap.
+        return f"refresh-issue-meta: {field} {old!r}{arrow}{new!r}"
+
+    old_repr = repr(old)
+    new_repr = repr(new)
+    half = budget_for_values // 2
+
+    def _elide(s: str, budget: int) -> str:
+        if len(s) <= budget:
+            return s
+        # Keep the opening and closing quote, elide the middle.
+        if budget < 5:
+            return s[:budget]
+        keep = budget - 1  # one char for the ellipsis
+        head = keep // 2
+        tail = keep - head
+        return s[:head] + "…" + s[-tail:]
+
+    old_disp = _elide(old_repr, half)
+    new_disp = _elide(new_repr, budget_for_values - len(old_disp))
+    return f"refresh-issue-meta: {field} {old_disp}{arrow}{new_disp}"
+
+
+def run_command() -> None:
+    """Typer-facing entry point. Translates exceptions to ``E_*`` exit codes
+    and emits the FR-008 diff line(s) on stdout.
+    """
+    try:
+        result = refresh(Path.cwd())
+    except NotInWorkspaceError as exc:
+        die(str(exc), code=E_NOT_IN_WORKSPACE)
+    except WorkspaceMalformedError as exc:
+        die(str(exc), code=E_WORKSPACE_MISSING)
+    except GhMissingError as exc:
+        die(str(exc), code=E_DEP_MISSING)
+    except IssueFetchError as exc:
+        die(str(exc), code=E_REPO_NOT_FOUND)
+    except ConcurrentModificationError as exc:
+        die(str(exc), code=1)
+    else:
+        if result.title_changed:
+            info(_diff_line("issue_title", result.old_title, result.new_title))
+        if result.url_changed:
+            info(_diff_line("issue_url", result.old_url, result.new_url))
+
+
+def cmd_refresh_issue_meta() -> None:
+    """Typer command body. Thin wrapper around ``run_command()`` for parallel
+    naming with the other ``cmd_*`` Typer entries in this package.
+    """
+    run_command()
+    raise typer.Exit(code=0)

--- a/tests/fixtures/workspace_md/malformed_missing_field.md
+++ b/tests/fixtures/workspace_md/malformed_missing_field.md
@@ -1,0 +1,11 @@
+---
+issue_url: https://github.com/App-Empire-LLC/DevKit/issues/39
+issue_owner_repo: App-Empire-LLC/DevKit
+issue_title: "devkit refresh-issue-meta"
+affected_repos:
+- App-Empire-LLC/DevKit
+trunk_branch: main
+status: active
+---
+
+## Notes

--- a/tests/fixtures/workspace_md/malformed_no_close.md
+++ b/tests/fixtures/workspace_md/malformed_no_close.md
@@ -1,0 +1,11 @@
+---
+issue_url: https://github.com/App-Empire-LLC/DevKit/issues/39
+issue_owner_repo: App-Empire-LLC/DevKit
+issue_number: 39
+issue_title: "devkit refresh-issue-meta"
+affected_repos:
+- App-Empire-LLC/DevKit
+trunk_branch: main
+status: active
+
+## Notes

--- a/tests/fixtures/workspace_md/valid.md
+++ b/tests/fixtures/workspace_md/valid.md
@@ -1,0 +1,17 @@
+---
+issue_url: https://github.com/App-Empire-LLC/DevKit/issues/39
+issue_owner_repo: App-Empire-LLC/DevKit
+issue_number: 39
+issue_title: "devkit refresh-issue-meta — re-fetch issue title into WORKSPACE.md"
+affected_repos:
+- App-Empire-LLC/DevKit
+- App-Empire-LLC/appire_docs
+trunk_branch: main
+stamp_date: '2026-05-12'
+stamp_devkit_version: 0.5.0
+stamp_config_sha: 80f0fb7
+template_stamp_sha: 78552c2c82ae69e7dcb61e744635a426c5e384b0bb9996846f9cb2907a2149ac
+status: active
+---
+
+## Notes

--- a/tests/integration/test_refresh_issue_meta_integration.py
+++ b/tests/integration/test_refresh_issue_meta_integration.py
@@ -1,0 +1,211 @@
+"""End-to-end integration tests for ``devkit refresh-issue-meta`` (DevKit#39).
+
+Drives the real installed ``devkit`` binary via subprocess against a tempdir
+workspace. ``gh`` is stubbed by PATH-prefixing a fake executable so we never
+hit the live GitHub API — the stub honors a JSON-payload file written by each
+test (and an "auth-fail" / "not-found" mode controlled by env vars).
+
+This complements the in-process unit tests in
+``tests/test_refresh_issue_meta.py`` by validating the actual Typer
+exception→exit-code translation and the on-disk write path.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_VALID_FIXTURE = _REPO_ROOT / "tests" / "fixtures" / "workspace_md" / "valid.md"
+
+# These constants mirror the fixture; keep them in sync if the fixture moves.
+_FIXTURE_TITLE = (
+    "devkit refresh-issue-meta — re-fetch issue title into WORKSPACE.md"
+)
+_FIXTURE_URL = "https://github.com/App-Empire-LLC/DevKit/issues/39"
+
+
+def _devkit_cmd() -> list[str]:
+    """Build the argv prefix for invoking ``devkit`` in this checkout.
+
+    Uses ``python -m aidevkit.cli`` when the entry point isn't on PATH;
+    falls back to bare ``devkit`` when it is. Either way we end up
+    exercising the same Typer app.
+    """
+    devkit = shutil.which("devkit")
+    if devkit:
+        return [devkit]
+    return [sys.executable, "-m", "aidevkit.cli"]
+
+
+@pytest.fixture
+def fake_gh_dir(tmp_path: Path) -> Path:
+    """Create a directory holding a fake ``gh`` script and its config file.
+
+    The fake reads ``<dir>/gh_response.json`` for a canned issue-view payload,
+    or honors mode files ``gh_auth_fail`` / ``gh_repo_not_found`` /
+    ``gh_missing`` to simulate the various failure modes from the spec.
+    """
+    bin_dir = tmp_path / "fakebin"
+    bin_dir.mkdir()
+    config_dir = tmp_path / "fakegh_config"
+    config_dir.mkdir()
+    fake_gh = bin_dir / "gh"
+    fake_gh.write_text(
+        f"""#!{sys.executable}
+import json, os, sys
+
+CONFIG_DIR = {str(config_dir)!r}
+args = sys.argv[1:]
+
+if args[:2] != ["issue", "view"]:
+    sys.stderr.write(f"fake gh: unexpected args {{args!r}}\\n")
+    sys.exit(2)
+
+if os.path.exists(os.path.join(CONFIG_DIR, "gh_auth_fail")):
+    sys.stderr.write("error: not logged into any GitHub hosts. Run `gh auth login`\\n")
+    sys.exit(1)
+
+if os.path.exists(os.path.join(CONFIG_DIR, "gh_repo_not_found")):
+    sys.stderr.write("GraphQL: Could not resolve to an Issue (issue: 99999)\\n")
+    sys.exit(1)
+
+response_path = os.path.join(CONFIG_DIR, "gh_response.json")
+with open(response_path) as f:
+    print(f.read(), end="")
+"""
+    )
+    fake_gh.chmod(0o755)
+    # Stash the config dir alongside the fake-bin dir for tests to write into.
+    (bin_dir / ".config_dir").write_text(str(config_dir))
+    return bin_dir
+
+
+def _write_gh_response(fake_gh_dir: Path, *, title: str, url: str) -> None:
+    config_dir = Path((fake_gh_dir / ".config_dir").read_text())
+    (config_dir / "gh_response.json").write_text(
+        json.dumps({"title": title, "url": url})
+    )
+
+
+def _set_gh_mode(fake_gh_dir: Path, mode: str) -> None:
+    """``mode`` ∈ {"auth_fail", "repo_not_found"}."""
+    config_dir = Path((fake_gh_dir / ".config_dir").read_text())
+    (config_dir / f"gh_{mode}").write_text("")
+
+
+def _stage_workspace(tmp_path: Path, fixture: Path = _VALID_FIXTURE) -> Path:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    shutil.copy(fixture, workspace / "WORKSPACE.md")
+    return workspace
+
+
+def _run_devkit(
+    args: list[str],
+    *,
+    cwd: Path,
+    fake_gh_dir: Path | None = None,
+    drop_gh_from_path: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    if fake_gh_dir is not None:
+        env["PATH"] = f"{fake_gh_dir}{os.pathsep}{env['PATH']}"
+    if drop_gh_from_path:
+        # Build a minimal PATH that excludes any directory containing `gh`.
+        clean_dirs = []
+        for d in env.get("PATH", "").split(os.pathsep):
+            if not d:
+                continue
+            if (Path(d) / "gh").exists():
+                continue
+            clean_dirs.append(d)
+        env["PATH"] = os.pathsep.join(clean_dirs)
+    return subprocess.run(
+        [*_devkit_cmd(), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# T019 (Phase 4) — in-sync no-op smoke
+# ---------------------------------------------------------------------------
+
+
+def test_runs_silently_when_in_sync(tmp_path: Path, fake_gh_dir: Path) -> None:
+    workspace = _stage_workspace(tmp_path)
+    _write_gh_response(fake_gh_dir, title=_FIXTURE_TITLE, url=_FIXTURE_URL)
+
+    before = (workspace / "WORKSPACE.md").read_bytes()
+    proc = _run_devkit(["refresh-issue-meta"], cwd=workspace, fake_gh_dir=fake_gh_dir)
+    after = (workspace / "WORKSPACE.md").read_bytes()
+
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout == "", f"expected empty stdout, got: {proc.stdout!r}"
+    assert after == before, "file must be byte-identical on no-op (SC-002)"
+
+
+# ---------------------------------------------------------------------------
+# T024 (Phase 6) — exit-code matrix
+# ---------------------------------------------------------------------------
+
+
+def test_exit_code_change_applied(tmp_path: Path, fake_gh_dir: Path) -> None:
+    workspace = _stage_workspace(tmp_path)
+    _write_gh_response(fake_gh_dir, title="NEW TITLE", url=_FIXTURE_URL)
+
+    proc = _run_devkit(["refresh-issue-meta"], cwd=workspace, fake_gh_dir=fake_gh_dir)
+
+    assert proc.returncode == 0, proc.stderr
+    # FR-008: one diff line on stdout per changed field.
+    assert "refresh-issue-meta" in proc.stdout
+    assert "issue_title" in proc.stdout
+    # The new title should now be in the file (sanity).
+    assert "NEW TITLE" in (workspace / "WORKSPACE.md").read_text()
+
+
+def test_exit_code_not_in_workspace(tmp_path: Path, fake_gh_dir: Path) -> None:
+    # tmp_path itself has no WORKSPACE.md.
+    proc = _run_devkit(["refresh-issue-meta"], cwd=tmp_path, fake_gh_dir=fake_gh_dir)
+
+    assert proc.returncode == 20, (proc.stdout, proc.stderr)
+    assert "WORKSPACE.md" in proc.stderr
+
+
+def test_exit_code_malformed_workspace(tmp_path: Path, fake_gh_dir: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "WORKSPACE.md").write_text("not yaml\nno frontmatter\n")
+
+    proc = _run_devkit(["refresh-issue-meta"], cwd=workspace, fake_gh_dir=fake_gh_dir)
+
+    assert proc.returncode == 16, (proc.stdout, proc.stderr)
+    assert "frontmatter" in proc.stderr.lower() or "delimiter" in proc.stderr.lower()
+
+
+def test_exit_code_gh_auth_fail(tmp_path: Path, fake_gh_dir: Path) -> None:
+    workspace = _stage_workspace(tmp_path)
+    _set_gh_mode(fake_gh_dir, "auth_fail")
+
+    proc = _run_devkit(["refresh-issue-meta"], cwd=workspace, fake_gh_dir=fake_gh_dir)
+
+    # Auth-shaped failures map to E_DEP_MISSING (12) per the contract.
+    assert proc.returncode == 12, (proc.stdout, proc.stderr)
+
+
+def test_exit_code_gh_repo_not_found(tmp_path: Path, fake_gh_dir: Path) -> None:
+    workspace = _stage_workspace(tmp_path)
+    _set_gh_mode(fake_gh_dir, "repo_not_found")
+
+    proc = _run_devkit(["refresh-issue-meta"], cwd=workspace, fake_gh_dir=fake_gh_dir)
+
+    # Other gh failures map to E_REPO_NOT_FOUND (13) per the contract.
+    assert proc.returncode == 13, (proc.stdout, proc.stderr)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,34 +24,40 @@ EXPECTED_HELP = """\
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ bootstrap     Create a per-issue workspace directory with per-repo git       │
-│               worktrees.                                                     │
-│ doctor        Check dependencies, required env vars, and gh authentication.  │
-│ setup         Link DevKit slash commands into ~/.claude/commands/ (runs      │
-│               doctor first).                                                 │
-│ sync          Fetch and rebase every worktree in the current workspace onto  │
-│               its trunk.                                                     │
-│ archive       Archive a completed per-issue workspace: post spec as issue    │
-│               comment, move workspace to _archived/, prune registrations.    │
-│ preflight     Check whether the current issue branch is behind origin/main   │
-│               (detect-only; no mutation).                                    │
-│ status        Summarize every active per-issue workspace: issue state,       │
-│               branches, PRs.                                                 │
-│ pr-create     Open PRs for the current sub-issue in an epic workspace with   │
-│               correct base branches.                                         │
-│ sub-merge     Verify PRs merged for the current sub-issue, advance epic      │
-│               pointer, cascade-up.                                           │
-│ sub-checkout  Switch all worktrees in an epic workspace to a sub-issue's     │
-│               branch.                                                        │
-│ add-repo      Add a sibling repo's worktree to the current per-issue         │
-│               workspace.                                                     │
-│ purge         Remove archived workspaces older than the retention threshold. │
-│ uninstall     Remove DevKit: uninstall aidevkit and unlink slash commands.   │
-│ update        Upgrade DevKit to the latest release, then run doctor.         │
-│ check-update  Check whether a newer aidevkit release is available.           │
-│ version       Print the installed aidevkit version.                          │
-│ review-issue  Review a GitHub issue against the App Empire issue-authoring   │
-│               standard.                                                      │
+│ bootstrap           Create a per-issue workspace directory with per-repo git │
+│                     worktrees.                                               │
+│ doctor              Check dependencies, required env vars, and gh            │
+│                     authentication.                                          │
+│ setup               Link DevKit slash commands into ~/.claude/commands/      │
+│                     (runs doctor first).                                     │
+│ sync                Fetch and rebase every worktree in the current workspace │
+│                     onto its trunk.                                          │
+│ archive             Archive a completed per-issue workspace: post spec as    │
+│                     issue comment, move workspace to _archived/, prune       │
+│                     registrations.                                           │
+│ preflight           Check whether the current issue branch is behind         │
+│                     origin/main (detect-only; no mutation).                  │
+│ refresh-issue-meta  Refresh issue_title / issue_url in WORKSPACE.md from the │
+│                     current GitHub issue state.                              │
+│ status              Summarize every active per-issue workspace: issue state, │
+│                     branches, PRs.                                           │
+│ pr-create           Open PRs for the current sub-issue in an epic workspace  │
+│                     with correct base branches.                              │
+│ sub-merge           Verify PRs merged for the current sub-issue, advance     │
+│                     epic pointer, cascade-up.                                │
+│ sub-checkout        Switch all worktrees in an epic workspace to a           │
+│                     sub-issue's branch.                                      │
+│ add-repo            Add a sibling repo's worktree to the current per-issue   │
+│                     workspace.                                               │
+│ purge               Remove archived workspaces older than the retention      │
+│                     threshold.                                               │
+│ uninstall           Remove DevKit: uninstall aidevkit and unlink slash       │
+│                     commands.                                                │
+│ update              Upgrade DevKit to the latest release, then run doctor.   │
+│ check-update        Check whether a newer aidevkit release is available.     │
+│ version             Print the installed aidevkit version.                    │
+│ review-issue        Review a GitHub issue against the App Empire             │
+│                     issue-authoring standard.                                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 """
 

--- a/tests/test_refresh_issue_meta.py
+++ b/tests/test_refresh_issue_meta.py
@@ -1,0 +1,346 @@
+"""Tests for ``aidevkit.refresh_issue_meta`` (DevKit#39).
+
+Spec: ``specs/001-refresh-issue-meta/spec.md`` in the per-issue workspace.
+All shell I/O is captured through the ``subprocess_capture`` fixture from
+``conftest.py`` (the hermeticity-guarded ``aidevkit.util.run`` seam).
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+from aidevkit import refresh_issue_meta as rim
+from aidevkit.util import RunResult
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "workspace_md"
+_VALID = _FIXTURES / "valid.md"
+_MALFORMED_NO_CLOSE = _FIXTURES / "malformed_no_close.md"
+_MALFORMED_MISSING_FIELD = _FIXTURES / "malformed_missing_field.md"
+
+# Title and URL as they appear in valid.md — kept here as constants so a
+# fixture rename doesn't silently desync the tests.
+_FIXTURE_TITLE = (
+    "devkit refresh-issue-meta — re-fetch issue title into WORKSPACE.md"
+)
+_FIXTURE_URL = "https://github.com/App-Empire-LLC/DevKit/issues/39"
+
+
+def _queue_gh(subprocess_capture, *, title: str, url: str) -> None:
+    """Convenience: queue a single fake `gh issue view --json title,url` response."""
+    subprocess_capture.queue(
+        RunResult(code=0, stdout=json.dumps({"title": title, "url": url}), stderr="")
+    )
+
+
+def _stage_workspace(tmp_workspace: Path, fixture: Path = _VALID) -> Path:
+    """Copy a fixture into ``tmp_workspace/WORKSPACE.md`` and return the workspace path."""
+    shutil.copy(fixture, tmp_workspace / "WORKSPACE.md")
+    return tmp_workspace
+
+
+# ---------------------------------------------------------------------------
+# T011 — _parse_workspace_md
+# ---------------------------------------------------------------------------
+
+
+class TestParseWorkspaceMd:
+    def test_parses_valid_fixture(self) -> None:
+        text = _VALID.read_text(encoding="utf-8")
+        owner_repo, number, title, url = rim._parse_workspace_md(text)
+        assert owner_repo == "App-Empire-LLC/DevKit"
+        assert number == 39
+        assert title == _FIXTURE_TITLE
+        assert url == _FIXTURE_URL
+
+    def test_raises_on_missing_close_delimiter(self) -> None:
+        text = _MALFORMED_NO_CLOSE.read_text(encoding="utf-8")
+        with pytest.raises(
+            rim.WorkspaceMalformedError, match=r"(?i)delimiter|frontmatter"
+        ):
+            rim._parse_workspace_md(text)
+
+    def test_raises_on_missing_field(self) -> None:
+        text = _MALFORMED_MISSING_FIELD.read_text(encoding="utf-8")
+        with pytest.raises(rim.WorkspaceMalformedError, match=r"issue_number"):
+            rim._parse_workspace_md(text)
+
+
+# ---------------------------------------------------------------------------
+# T012, T017, T018, T020, T021 — refresh() behavior matrix
+# ---------------------------------------------------------------------------
+
+
+class TestRefresh:
+    def test_title_drift_updates_only_title_line(
+        self, tmp_workspace: Path, subprocess_capture
+    ) -> None:
+        """T012 (US1) — title-only drift rewrites exactly one line."""
+        _stage_workspace(tmp_workspace)
+        original_bytes = (tmp_workspace / "WORKSPACE.md").read_bytes()
+        listing_before = sorted(os.listdir(tmp_workspace))
+
+        _queue_gh(subprocess_capture, title="UPDATED TITLE", url=_FIXTURE_URL)
+
+        result = rim.refresh(tmp_workspace)
+
+        assert result.title_changed is True
+        assert result.url_changed is False
+        assert result.old_title == _FIXTURE_TITLE
+        assert result.new_title == "UPDATED TITLE"
+        assert result.old_url == _FIXTURE_URL
+        assert result.new_url == _FIXTURE_URL
+
+        new_bytes = (tmp_workspace / "WORKSPACE.md").read_bytes()
+        old_lines = original_bytes.decode("utf-8").splitlines()
+        new_lines = new_bytes.decode("utf-8").splitlines()
+        assert len(old_lines) == len(new_lines), "line count must be preserved"
+        diff_lines = [
+            (idx, a, b)
+            for idx, (a, b) in enumerate(zip(old_lines, new_lines))
+            if a != b
+        ]
+        assert len(diff_lines) == 1, f"expected one changed line, got: {diff_lines}"
+        idx, _old, new = diff_lines[0]
+        assert new.startswith("issue_title:")
+
+        # Parse the new file to confirm it round-trips and reports the new title.
+        _, _, parsed_title, parsed_url = rim._parse_workspace_md(
+            new_bytes.decode("utf-8")
+        )
+        assert parsed_title == "UPDATED TITLE"
+        assert parsed_url == _FIXTURE_URL
+
+        # FR-007: no other file was created or modified in the workspace.
+        assert sorted(os.listdir(tmp_workspace)) == listing_before
+
+    def test_no_op_when_in_sync(
+        self, tmp_workspace: Path, subprocess_capture
+    ) -> None:
+        """T017 (US2) — byte-identical when nothing drifted (SC-002)."""
+        _stage_workspace(tmp_workspace)
+        workspace_md = tmp_workspace / "WORKSPACE.md"
+        original_bytes = workspace_md.read_bytes()
+        original_mtime = workspace_md.stat().st_mtime_ns
+
+        _queue_gh(subprocess_capture, title=_FIXTURE_TITLE, url=_FIXTURE_URL)
+
+        result = rim.refresh(tmp_workspace)
+
+        assert result.any_changed is False
+        assert workspace_md.read_bytes() == original_bytes
+        assert workspace_md.stat().st_mtime_ns == original_mtime
+
+    def test_round_trip_stability(
+        self, tmp_workspace: Path, subprocess_capture
+    ) -> None:
+        """T018 (US2) — second invocation is a true no-op (FR-012, SC-004)."""
+        _stage_workspace(tmp_workspace)
+        workspace_md = tmp_workspace / "WORKSPACE.md"
+
+        _queue_gh(subprocess_capture, title="REFRESHED TITLE", url=_FIXTURE_URL)
+        first = rim.refresh(tmp_workspace)
+        assert first.title_changed is True
+        first_bytes = workspace_md.read_bytes()
+        first_mtime = workspace_md.stat().st_mtime_ns
+
+        _queue_gh(subprocess_capture, title="REFRESHED TITLE", url=_FIXTURE_URL)
+        second = rim.refresh(tmp_workspace)
+
+        assert second.any_changed is False
+        assert workspace_md.read_bytes() == first_bytes
+        assert workspace_md.stat().st_mtime_ns == first_mtime
+
+    def test_url_drift_updates_only_url_line(
+        self, tmp_workspace: Path, subprocess_capture
+    ) -> None:
+        """T020 (US3) — URL-only drift rewrites exactly one line."""
+        _stage_workspace(tmp_workspace)
+        original_bytes = (tmp_workspace / "WORKSPACE.md").read_bytes()
+
+        new_url = "https://github.com/App-Empire-LLC/devkit-renamed/issues/39"
+        _queue_gh(subprocess_capture, title=_FIXTURE_TITLE, url=new_url)
+
+        result = rim.refresh(tmp_workspace)
+
+        assert result.title_changed is False
+        assert result.url_changed is True
+        assert result.new_url == new_url
+
+        new_bytes = (tmp_workspace / "WORKSPACE.md").read_bytes()
+        old_lines = original_bytes.decode("utf-8").splitlines()
+        new_lines = new_bytes.decode("utf-8").splitlines()
+        diff_lines = [
+            (idx, a, b)
+            for idx, (a, b) in enumerate(zip(old_lines, new_lines))
+            if a != b
+        ]
+        assert len(diff_lines) == 1
+        assert diff_lines[0][2].startswith("issue_url:")
+
+    def test_both_fields_drift_updates_both_lines(
+        self, tmp_workspace: Path, subprocess_capture
+    ) -> None:
+        """T021 (US3) — both fields drift updates exactly two lines (SC-003)."""
+        _stage_workspace(tmp_workspace)
+        original_bytes = (tmp_workspace / "WORKSPACE.md").read_bytes()
+
+        new_url = "https://github.com/App-Empire-LLC/devkit-renamed/issues/39"
+        _queue_gh(subprocess_capture, title="NEW TITLE", url=new_url)
+
+        result = rim.refresh(tmp_workspace)
+
+        assert result.title_changed is True
+        assert result.url_changed is True
+
+        new_bytes = (tmp_workspace / "WORKSPACE.md").read_bytes()
+        old_lines = original_bytes.decode("utf-8").splitlines()
+        new_lines = new_bytes.decode("utf-8").splitlines()
+        diff_lines = [
+            (idx, a, b)
+            for idx, (a, b) in enumerate(zip(old_lines, new_lines))
+            if a != b
+        ]
+        assert len(diff_lines) == 2
+        changed_keys = sorted(b.split(":", 1)[0] for _, _, b in diff_lines)
+        assert changed_keys == ["issue_title", "issue_url"]
+
+
+# ---------------------------------------------------------------------------
+# T023 — failure-path cases (SC-005), concurrent-edit guard, SC-006 elision
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshFailures:
+    def test_raises_not_in_workspace_when_md_absent(self, tmp_workspace: Path) -> None:
+        with pytest.raises(rim.NotInWorkspaceError, match=r"WORKSPACE\.md not found"):
+            rim.refresh(tmp_workspace)
+
+    def test_raises_workspace_malformed_when_no_close_delim(
+        self, tmp_workspace: Path
+    ) -> None:
+        _stage_workspace(tmp_workspace, _MALFORMED_NO_CLOSE)
+        with pytest.raises(
+            rim.WorkspaceMalformedError, match=r"(?i)delimiter|frontmatter"
+        ):
+            rim.refresh(tmp_workspace)
+
+    def test_raises_workspace_malformed_when_missing_field(
+        self, tmp_workspace: Path
+    ) -> None:
+        _stage_workspace(tmp_workspace, _MALFORMED_MISSING_FIELD)
+        with pytest.raises(rim.WorkspaceMalformedError, match=r"issue_number"):
+            rim.refresh(tmp_workspace)
+
+    def test_raises_gh_missing_when_gh_not_on_path(
+        self, tmp_workspace: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _stage_workspace(tmp_workspace)
+
+        def _raise_filenotfound(*args, **kwargs):
+            raise FileNotFoundError("gh")
+
+        monkeypatch.setattr("aidevkit.util.run", _raise_filenotfound)
+        with pytest.raises(rim.GhMissingError, match=r"(?i)gh.*(not found|PATH)"):
+            rim.refresh(tmp_workspace)
+
+    def test_raises_gh_missing_when_unauthenticated(
+        self, tmp_workspace: Path, subprocess_capture
+    ) -> None:
+        _stage_workspace(tmp_workspace)
+        subprocess_capture.queue(
+            RunResult(
+                code=1,
+                stdout="",
+                stderr="error: not logged into any GitHub hosts. Run `gh auth login`",
+            )
+        )
+        with pytest.raises(rim.GhMissingError, match=r"(?i)authenticat|auth login"):
+            rim.refresh(tmp_workspace)
+
+    def test_raises_issue_fetch_when_gh_returns_nonzero(
+        self, tmp_workspace: Path, subprocess_capture
+    ) -> None:
+        _stage_workspace(tmp_workspace)
+        subprocess_capture.queue(
+            RunResult(
+                code=1,
+                stdout="",
+                stderr=(
+                    "GraphQL: Could not resolve to an Issue with the number "
+                    "of 99999 (issue: 99999)"
+                ),
+            )
+        )
+        with pytest.raises(
+            rim.IssueFetchError, match=r"(?i)gh issue view|fetch|issue"
+        ):
+            rim.refresh(tmp_workspace)
+
+    def test_aborts_on_concurrent_modification(
+        self,
+        tmp_workspace: Path,
+        subprocess_capture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _stage_workspace(tmp_workspace)
+        workspace_md = tmp_workspace / "WORKSPACE.md"
+        _queue_gh(subprocess_capture, title="NEW TITLE", url=_FIXTURE_URL)
+
+        # Simulate a concurrent editor: bump the file's mtime between the
+        # initial read and the write-time recheck by patching the second
+        # `Path.stat` call.
+        real_stat = Path.stat
+        call_state = {"count": 0}
+
+        def _stat_with_drift(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            result = real_stat(self, *args, **kwargs)
+            # Only meddle with stats of our specific workspace_md file.
+            if self != workspace_md:
+                return result
+            call_state["count"] += 1
+            # On the second call (the write-time recheck), claim mtime moved.
+            if call_state["count"] == 2:
+                class _Fake:
+                    st_mtime_ns = result.st_mtime_ns + 1
+                return _Fake()
+            return result
+
+        monkeypatch.setattr(Path, "stat", _stat_with_drift)
+
+        bytes_before = workspace_md.read_bytes()
+        with pytest.raises(
+            rim.ConcurrentModificationError, match=r"(?i)changed during refresh"
+        ):
+            rim.refresh(tmp_workspace)
+        # File untouched (we read it pre-race).
+        assert workspace_md.read_bytes() == bytes_before
+
+
+# ---------------------------------------------------------------------------
+# T023 — SC-006 (diff line elision)
+# ---------------------------------------------------------------------------
+
+
+class TestDiffLine:
+    def test_short_title_renders_full(self) -> None:
+        line = rim._diff_line("issue_title", "old", "new")
+        # ellipsis only appears on overflow
+        assert "…" not in line
+        assert "issue_title" in line
+        assert "old" in line and "new" in line
+
+    def test_long_title_elides_to_120_cols(self) -> None:
+        long_old = "A" * 200
+        long_new = "B" * 200
+        line = rim._diff_line("issue_title", long_old, long_new)
+        # The "[devkit] " prefix is added by util.info() at print time; the
+        # raw line stays under 120 - len("[devkit] ") = 111 chars.
+        max_target = 120 - len("[devkit] ")
+        assert len(line) <= max_target, (
+            f"diff line length {len(line)} > {max_target} (SC-006)"
+        )
+        assert "…" in line


### PR DESCRIPTION
## Summary

Adds `devkit refresh-issue-meta` — a workspace-root subcommand that pulls the current title and canonical URL from GitHub via `gh issue view` and surgically updates `WORKSPACE.md.issue_title` / `issue_url` if they've drifted. Closes #39.

- **Opt-in**: explicit invocation only; never called from `devkit status` (would burn rate limit).
- **Scoped**: only `issue_title` and `issue_url` lines ever change; no other field, no other file.
- **Idempotent**: in-sync workspace ⇒ no write, no stdout, exit 0.
- **Surgical line-edit** (not yaml round-trip dump) so quoting/ordering of unchanged fields is preserved by construction.

## Exit code map (reuses existing `E_*` constants)

| Code | Meaning |
|------|---------|
| `0` | Success — changed (diff line on stdout) or no-op (silent). |
| `12` (`E_DEP_MISSING`) | `gh` missing or unauthenticated. |
| `13` (`E_REPO_NOT_FOUND`) | `gh issue view` failed (issue gone, network, rate limit, etc.). |
| `16` (`E_WORKSPACE_MISSING`) | `WORKSPACE.md` present but malformed. |
| `20` (`E_NOT_IN_WORKSPACE`) | `WORKSPACE.md` absent from cwd. |
| `1` | Concurrent modification detected (mtime moved between read and write). |

## Note on FR-013 (shape contract)

The source issue listed a dependency on #37, expecting `refresh-constitution` / `refresh-templates` commands to already exist. They don't — PR #43 closed #37 with a different scope (tiered `.devkit/` config + templates). This is therefore **the first member of the `refresh-*` family**. Its shape — opt-in / scoped / diff-on-change / no-op-on-unchanged — defines the contract for subsequent `refresh-*` commands going forward.

## Tests

- **23 new tests** (17 unit + 6 integration) covering every FR + SC in the spec:
  - `_parse_workspace_md` happy path + 2 malformed cases
  - `refresh()` matrix: title-only drift, url-only drift, both drift, no-op, round-trip stability
  - failure paths: not-in-workspace, malformed (no close delim / missing field), gh missing, gh auth fail, gh repo not found, concurrent modification
  - `_diff_line` short + long (SC-006 120-col elision)
  - integration: subprocess-driven `devkit refresh-issue-meta` against a tempdir workspace with a fake `gh` on PATH for each exit-code scenario
- Full DevKit suite: 432 passed (357 pre-existing + 23 new + 52 from #55 already on main).
- `tests/test_cli.py` `--help` snapshot updated to include the new command alongside #55's epic commands.
- `ruff check src/aidevkit/refresh_issue_meta.py src/aidevkit/cli.py tests/test_refresh_issue_meta.py tests/integration/test_refresh_issue_meta_integration.py tests/test_cli.py` — clean. (Pre-existing #55 lint debt on `main` in `test_epic_*.py` / `test_pr_create.py` / `test_sub_*.py` is unaffected by this PR.)

## Test plan

- [x] Unit tests pass (`pytest tests/test_refresh_issue_meta.py`)
- [x] Integration tests pass (`pytest tests/integration/test_refresh_issue_meta_integration.py`)
- [x] Full DevKit suite green (`pytest`)
- [x] Hermeticity guard intact (`pytest tests/test_hermeticity.py`)
- [x] Ruff clean on all new/modified files
- [x] `devkit refresh-issue-meta --help` renders correctly
- [x] `--help` snapshot test updated
- [ ] Manual quickstart pass against the real `App-Empire-LLC/DevKit#39` issue: rename on GitHub → run command → verify `WORKSPACE.md` updates → restore title

🤖 Generated with [Claude Code](https://claude.com/claude-code)