### PR TITLE
docs(commands): add missing slash-command prompts for epic lifecycle

### DIFF
--- a/src/aidevkit/commands/devkit.pr-create.md
+++ b/src/aidevkit/commands/devkit.pr-create.md
@@ -1,0 +1,63 @@
+---
+description: Open stacked PRs for the current sub-issue in an epic workspace
+---
+
+# /devkit.pr-create
+
+Open one PR per effective repo for the **current sub-issue** in an epic workspace, with each PR's base branch wired to the parent sub-issue's branch (or `origin/<default_branch>` if this is the top epic). Cross-links sibling PRs in each body and marks the sub-issue `in_review` in `EPIC.md`.
+
+The epic workspace model is documented in `appire_docs/docs/workflows/devkit-workspaces.md` and `DevKit/docs/epic-workspaces.md`.
+
+## Usage
+
+```bash
+/devkit.pr-create
+/devkit.pr-create --dry-run
+```
+
+There are no positional arguments — the target is whatever `EPIC.md#current_issue` points at. To open PRs for a different sub-issue, first `/devkit.sub-checkout <N>` (which enforces serial order) or — only if the user explicitly directs — edit `current_issue` in `EPIC.md` manually.
+
+## What to do
+
+1. Confirm you are inside an epic workspace (the workspace dir contains `EPIC.md`). Run the command from anywhere inside the workspace:
+
+       devkit pr-create
+       devkit pr-create --dry-run
+
+2. `--dry-run` skips both the PR-create and PR-edit calls, but still walks the graph and reports the base branch and effective repos that *would* be targeted. It does NOT update `EPIC.md`.
+
+3. **Common exit codes** (each names the offending input in its message):
+   - **20** `E_NOT_IN_WORKSPACE` — CWD is not inside a workspace directory under `workspaces_home`.
+   - **31** `E_EPIC_GRAPH_INVALID` — no `EPIC.md` in the workspace, or it failed to parse. Non-epic workspaces don't have one — pr-create is epic-only.
+
+## How base branches are computed
+
+For the current sub-issue `N`:
+
+- If `N` has a **parent** in the epic graph, each PR's `--base` is the **parent's** stacked branch (`issue-<repo>-<parent_num>`). This is the stacking — child PRs target parent branches, not `main`.
+- If `N` is the **top epic** (no parent), each PR's `--base` is `origin/<default_branch>` of that repo (typically `origin/main`). The top epic's PRs are the only ones that ever target `main`.
+
+Do not propose flattening this to "everything targets main" — the stacked-base model is what makes the cascade-up review flow work.
+
+## Two-pass PR body editing
+
+`pr-create` runs two passes:
+
+1. **Pass 1**: create each PR with a minimal body that names the sub-issue.
+2. **Pass 2**: edit each PR's body to add a `## Sibling PRs` section cross-linking the other PRs opened in the same run. This only happens when more than one PR was opened.
+
+If pass-2 fails for any single PR, the command logs a WARN and continues — the PR itself still exists, just without cross-links. Don't retry the whole command on a pass-2 WARN; surface it and let the user decide whether to edit by hand.
+
+## Status transition
+
+On success, the sub-issue's node in `EPIC.md` flips from `in_progress` → `in_review`. The `current_issue` pointer does **not** advance — only `/devkit.sub-merge` advances it.
+
+## Cascade-up note
+
+`pr-create` is also called automatically by `/devkit.sub-merge` when all of a parent's children become merged (the cascade-up step). You normally only run `pr-create` directly for the *current* sub-issue; the parent's PRs open themselves via cascade.
+
+## Notes
+
+- Each PR title defaults to the sub-issue's GitHub title, prefixed with `[epic]`. If the `gh issue view` call fails, the title falls back to `[epic] <owner/repo#N>` — surface this rather than retrying.
+- `pr-create` requires that the sub-issue's branch has been pushed to `origin` in every effective repo. If a `gh pr create` call fails because the branch doesn't exist on the remote, push first and re-run.
+- Do not try to "help" by force-pushing or rebasing if PR creation fails. Stop, surface the error, let the user decide.

--- a/src/aidevkit/commands/devkit.sub-checkout.md
+++ b/src/aidevkit/commands/devkit.sub-checkout.md
@@ -1,0 +1,60 @@
+---
+description: Switch all worktrees in an epic workspace to a sub-issue's branch
+---
+
+# /devkit.sub-checkout
+
+Switch every worktree in an **epic workspace** to the branch for a specific sub-issue, then update `EPIC.md` so the workspace remembers which sub-issue is active. This is the "I'm about to work on sub-issue N" command in the epic lifecycle.
+
+The epic workspace model is documented in `appire_docs/docs/workflows/devkit-workspaces.md` and `DevKit/docs/epic-workspaces.md`.
+
+## Usage
+
+The user will give you a sub-issue reference. Any of these forms is accepted:
+
+- Bare number: `7`
+- Hash form: `#7`
+- Fully qualified: `App-Empire-LLC/AuthService#7`
+
+```bash
+/devkit.sub-checkout 7
+/devkit.sub-checkout #7
+/devkit.sub-checkout App-Empire-LLC/AuthService#7
+```
+
+## What to do
+
+1. Confirm you are inside an epic workspace (the workspace dir contains `EPIC.md`). If you are not, the command exits with `E_NOT_IN_WORKSPACE` (20) or `E_EPIC_GRAPH_INVALID` (31).
+
+2. Run the command from anywhere inside the workspace:
+
+       devkit sub-checkout <ref>
+
+3. **Common exit codes** (each names the offending input in its message):
+   - **20** `E_NOT_IN_WORKSPACE` — CWD is not inside a workspace directory under `workspaces_home`.
+   - **31** `E_EPIC_GRAPH_INVALID` — no `EPIC.md` in the workspace, or it failed to parse. Non-epic workspaces don't have one — sub-checkout is epic-only.
+   - **33** `E_NODE_NOT_FOUND` — the given number/ref isn't a node in this epic's graph.
+   - **32** `E_DIRTY_WORKTREE` — at least one worktree in `effective(N)` has uncommitted changes. Commit or stash, then retry.
+   - **2** `E_USAGE` — usually means **serial enforcement** kicked in (see below).
+
+## Serial enforcement (FR-030)
+
+`sub-checkout` only succeeds when the target sub-issue matches `EPIC.md#current_issue`. This is by design: sub-issues are worked one at a time in execution order so the stacked branches don't get tangled.
+
+If the user tries to check out a different node:
+
+- Surface the error verbatim and don't try to work around it.
+- The error message names the current pointer. Either `devkit sub-merge <current>` to finish the in-flight one, or — if the user genuinely needs to skip ahead — edit `current_issue` in `EPIC.md` manually. The escape hatch is intentional and human-driven; do not edit `EPIC.md` on the user's behalf without explicit instruction.
+
+If `current_issue` already equals `top_epic`, every sub-issue has been merged. The error will say so; recommend `devkit pr-create` or `devkit sub-merge` on the top epic instead.
+
+## Dirty-check scope
+
+Only worktrees in the sub-issue's **effective repos** are dirty-checked. A workspace can contain worktrees outside the current sub-issue's scope (e.g., from a sibling sub-issue), and those will NOT block checkout. This is the documented clarification (Q2) from issue #42 — preserve it; don't propose a "check all worktrees" workaround.
+
+## Notes
+
+- On success, every effective-repos worktree has been switched to `node.branch_name` and `EPIC.md` records `current_issue = <ref>` and the node's `status = in_progress`.
+- `sub-checkout` performs `git checkout <branch>` — it does NOT fetch, rebase, or merge. Use `/devkit.sync` separately if branches are stale.
+- The command never mutates `main` or any branch other than the target sub-issue's stacked branch in each worktree.
+- Do not try to "help" by running destructive git commands if checkout fails. Stop, surface the error, let the user decide.

--- a/src/aidevkit/commands/devkit.sub-merge.md
+++ b/src/aidevkit/commands/devkit.sub-merge.md
@@ -1,0 +1,61 @@
+---
+description: Mark a sub-issue's PRs merged, advance the epic pointer, and cascade-up
+---
+
+# /devkit.sub-merge
+
+Verify that every PR for a sub-issue is merged on GitHub, mark the node `merged` in `EPIC.md`, advance `current_issue` to the next sub-issue in execution order, and — if this completes a parent's children — cascade-up by opening the parent's PRs.
+
+The epic workspace model is documented in `appire_docs/docs/workflows/devkit-workspaces.md` and `DevKit/docs/epic-workspaces.md`.
+
+## Usage
+
+The user will give you a sub-issue reference. Any of these forms is accepted:
+
+- Bare number: `7`
+- Hash form: `#7`
+- Fully qualified: `App-Empire-LLC/AuthService#7`
+
+```bash
+/devkit.sub-merge 7
+/devkit.sub-merge #7
+/devkit.sub-merge App-Empire-LLC/AuthService#7
+```
+
+The sub-issue must be a node in the current workspace's `EPIC.md` graph.
+
+## What to do
+
+1. Confirm you are inside an epic workspace (the workspace dir contains `EPIC.md`). Run the command from anywhere inside the workspace:
+
+       devkit sub-merge <ref>
+
+2. **Common exit codes** (each names the offending input in its message):
+   - **20** `E_NOT_IN_WORKSPACE` — CWD is not inside a workspace directory under `workspaces_home`.
+   - **31** `E_EPIC_GRAPH_INVALID` — no `EPIC.md`, or it failed to parse.
+   - **33** `E_NODE_NOT_FOUND` — the given number/ref isn't a node in this epic's graph.
+   - **34** `E_PRS_NOT_MERGED` — at least one PR for the sub-issue's branch is still open. The error message lists the blockers; surface them and stop. Do NOT try to merge them via `gh pr merge` — merges are human-driven.
+
+## PR verification
+
+`sub-merge` checks each effective repo's clone for a PR whose head matches the sub-issue's branch (`issue-<repo>-<N>`) and confirms its state is `merged`. If any are not merged, the command exits cleanly with `E_PRS_NOT_MERGED` and does **not** mutate `EPIC.md`.
+
+## Pointer advance
+
+On success the node's `status` flips to `merged`. `current_issue` advances to the next node in `execution_order`. When `execution_order` is exhausted, `current_issue` points at `top_epic` (clarification Q5) — this is the signal that the whole epic is ready for its own PRs.
+
+## Cascade-up (one level only)
+
+After advancing the pointer, `sub-merge` checks the merged node's **parent**:
+
+- If **all** of the parent's children are now `merged`, `sub-merge` calls `pr-create` for the parent, flips the parent's status to `in_review`, and stops.
+- The parent is NOT auto-marked `merged`. The user must still run `/devkit.sub-merge <parent>` once its PRs land — that's the explicit human gate from FR-024.
+
+Cascade-up is exactly one level deep per call. If a chain of parents all complete at once, each level requires its own `sub-merge` invocation.
+
+## Notes
+
+- `sub-merge` never closes or merges PRs; it only verifies state and mutates `EPIC.md`. If PRs are open, point the user at `/devkit.pr-create` (to open) or the GitHub UI (to merge).
+- After `sub-merge`, the next `/devkit.sub-checkout` should target the new `current_issue`. Re-read `EPIC.md` if you need to confirm what that is.
+- The `archive` command refuses to run on an epic workspace unless every node is `merged` (use `--force` only at the user's explicit direction).
+- Do not try to "help" by running destructive git or `gh` commands if verification fails. Stop, surface the error, let the user decide.


### PR DESCRIPTION
## Summary

- Adds the three `~/.claude/commands/devkit.*.md` prompts that were missing from #55: `pr-create`, `sub-checkout`, `sub-merge`.
- The CLI subcommands have shipped in `devkit --help` since v0.4.x, but Claude Code never saw them because `devkit setup` only symlinks `*.md` files it finds under `src/aidevkit/commands/` — and there were none for these three.

## What was missed

PR #55's task list (Phases 1-8, tasks T009-T058) mapped to Python modules + tests but had no T-id for slash-command markdown. Earlier releases (e.g. v0.3.0 in `af3bb09`) had explicit T028+T030 "slash-command refresh" tasks; this one didn't.

## Prompt contents

Each prompt follows the `devkit.bootstrap.md` convention (frontmatter description, Usage, exit codes, "don't try to help with destructive commands" guardrail) and encodes operating procedure from the matching Python module:

- **`devkit.sub-checkout.md`** — serial enforcement (FR-030), dirty-check scope (clarification Q2), escape-hatch guidance.
- **`devkit.pr-create.md`** — stacked-base computation, two-pass cross-linking, `--dry-run`, cascade-up note.
- **`devkit.sub-merge.md`** — PR verification, pointer advance (clarification Q5), one-level cascade-up (FR-024).

## Suggested follow-up (separate issue)

Add a parity test asserting every `@app.command` in `cli.py` has a matching `devkit.<name>.md` under `src/aidevkit/commands/`. Would have caught this at PR-time.

## Test plan

- [ ] `uv tool install --reinstall --from . aidevkit` succeeds
- [ ] `devkit setup` links 12 slash commands (was 9)
- [ ] In a fresh `claude` session, `/devkit.pr-create`, `/devkit.sub-checkout`, `/devkit.sub-merge` appear and show the new prompt content
- [ ] No regressions on existing prompts (the 9 pre-existing files are untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)