### PR TITLE
feat(doctor): check CLI ↔ slash-command prompt parity

### DIFF
--- a/src/aidevkit/doctor.py
+++ b/src/aidevkit/doctor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import shutil
+from importlib.resources import files
 
 import typer
 
@@ -9,6 +10,18 @@ from . import projects as _projects
 from .util import E_DEP_MISSING, err, gh, out
 
 _LABEL_WIDTH = 28
+
+# Top-level CLI commands that intentionally have no slash-command counterpart.
+# These are install / lifecycle / introspection commands meant to be run from
+# the shell, not from a Claude Code session.
+_NO_PROMPT_COMMANDS: frozenset[str] = frozenset({
+    "doctor",
+    "setup",
+    "uninstall",
+    "update",
+    "check-update",
+    "version",
+})
 
 
 def _ok(label: str, value: str) -> None:
@@ -83,6 +96,70 @@ def _check_devkit_setup() -> bool:
     return True
 
 
+def _registered_cli_command_names() -> set[str]:
+    """Top-level CLI command names as they appear in `devkit --help`.
+
+    Uses Typer's Click bridge so hyphenation is already applied (underscore-
+    named callbacks like `pr_create` resolve to `pr-create`). Imported lazily
+    to avoid a cli ↔ doctor import cycle.
+    """
+    from typer.main import get_group
+
+    from .cli import app
+
+    return set(get_group(app).commands.keys())
+
+
+def _bundled_slash_prompt_names() -> set[str]:
+    """Slash-command base-names shipped under aidevkit/commands/.
+
+    `devkit.<name>.md` → `<name>`. Anything that doesn't match this pattern
+    is ignored — the package directory ships only `devkit.*.md` today, but
+    the prefix check guards against future stray files.
+    """
+    pkg = files("aidevkit.commands")
+    names: set[str] = set()
+    for entry in pkg.iterdir():
+        n = entry.name
+        if n.startswith("devkit.") and n.endswith(".md"):
+            names.add(n[len("devkit.") : -len(".md")])
+    return names
+
+
+def _check_slash_command_parity() -> bool:
+    """Verify every user-facing CLI command has a matching slash-command prompt.
+
+    Catches the failure mode where a PR adds a Typer command but forgets the
+    corresponding `src/aidevkit/commands/devkit.<name>.md` — the symptom is
+    a CLI that works but a `devkit setup` that silently links fewer prompts
+    than there are commands.
+    """
+    cli_names = _registered_cli_command_names() - _NO_PROMPT_COMMANDS
+    prompt_names = _bundled_slash_prompt_names()
+    missing = sorted(cli_names - prompt_names)
+    orphan = sorted(prompt_names - cli_names)
+
+    if not missing and not orphan:
+        _ok(
+            "slash-command parity",
+            f"{len(prompt_names)} prompt(s) match registered CLI commands",
+        )
+        return True
+
+    if missing:
+        _fail(
+            "slash-command parity",
+            "CLI command(s) without prompt under src/aidevkit/commands/: "
+            + ", ".join(missing),
+        )
+    if orphan:
+        _fail(
+            "slash-command parity",
+            "prompt(s) without matching CLI command: " + ", ".join(orphan),
+        )
+    return False
+
+
 def cmd_doctor() -> int:
     out.print("[devkit] DevKit doctor — checking dependencies and environment")
 
@@ -92,6 +169,7 @@ def cmd_doctor() -> int:
 
     results.append(_check_devkit_setup())
     results.append(_check_gh_auth())
+    results.append(_check_slash_command_parity())
 
     failed = sum(1 for ok in results if not ok)
     if failed:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -173,6 +173,85 @@ def test_doctor_no_longer_checks_app_empire_envs(
     assert "APP_EMPIRE" not in result.output
 
 
+def test_doctor_reports_missing_slash_command_prompt(
+    runner: CliRunner,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    subprocess_capture,
+) -> None:
+    """A registered CLI command without a matching prompt must fail the doctor."""
+    _seed_devkit(tmp_path, monkeypatch)
+    monkeypatch.setattr("aidevkit.doctor.shutil.which", _all_present_which(tmp_path))
+    subprocess_capture.set_default(
+        RunResult(code=0, stdout="", stderr="Logged in to github.com as test-user")
+    )
+
+    from aidevkit import doctor as doctor_module
+
+    real_prompts = doctor_module._bundled_slash_prompt_names()
+    # Drop one real prompt name so the registered CLI command of the same
+    # name is reported as missing — proves the failure surfaces, not just
+    # that the function runs.
+    monkeypatch.setattr(
+        doctor_module,
+        "_bundled_slash_prompt_names",
+        lambda: real_prompts - {"bootstrap"},
+    )
+
+    result = runner.invoke(app, ["doctor"])
+
+    assert result.exit_code != 0, result.output
+    assert "[FAIL]" in result.output
+    assert "slash-command parity" in result.output
+    assert "bootstrap" in result.output
+
+
+def test_doctor_reports_orphan_slash_command_prompt(
+    runner: CliRunner,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    subprocess_capture,
+) -> None:
+    """A prompt with no matching CLI command must also fail the doctor."""
+    _seed_devkit(tmp_path, monkeypatch)
+    monkeypatch.setattr("aidevkit.doctor.shutil.which", _all_present_which(tmp_path))
+    subprocess_capture.set_default(
+        RunResult(code=0, stdout="", stderr="Logged in to github.com as test-user")
+    )
+
+    from aidevkit import doctor as doctor_module
+
+    real_prompts = doctor_module._bundled_slash_prompt_names()
+    monkeypatch.setattr(
+        doctor_module,
+        "_bundled_slash_prompt_names",
+        lambda: real_prompts | {"phantom-command"},
+    )
+
+    result = runner.invoke(app, ["doctor"])
+
+    assert result.exit_code != 0, result.output
+    assert "[FAIL]" in result.output
+    assert "slash-command parity" in result.output
+    assert "phantom-command" in result.output
+
+
+def test_slash_command_parity_excludes_lifecycle_commands() -> None:
+    """Unit-level: lifecycle commands must not be required to have prompts."""
+    from aidevkit.doctor import (
+        _NO_PROMPT_COMMANDS,
+        _registered_cli_command_names,
+    )
+
+    cli = _registered_cli_command_names()
+    # Every excluded name must actually be a registered CLI command — if one
+    # is removed from cli.py, the allow-list should be pruned to match.
+    stale_exclusions = _NO_PROMPT_COMMANDS - cli
+    assert not stale_exclusions, (
+        f"_NO_PROMPT_COMMANDS contains names not in the CLI: {stale_exclusions}"
+    )
+
+
 def test_doctor_reports_gh_not_authed(
     runner: CliRunner,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

`devkit doctor` now catches the failure mode that landed PRs #55 → #57: a Typer command exists in `cli.py` but its `src/aidevkit/commands/devkit.<name>.md` prompt was never authored, so the CLI works from the shell but Claude Code can't see the command after `devkit setup`.

The check runs bidirectionally:

- **Missing prompt** — registered CLI command without a matching `devkit.<name>.md`.
- **Orphan prompt** — `devkit.<name>.md` referencing a CLI command that no longer exists.

Because `devkit setup` runs doctor first, parity failures now also block setup — surfacing the defect at install time, not on the next session start.

## Allow-list

Six install/lifecycle commands are deliberately shell-only (no slash-command counterpart):

\`\`\`python
_NO_PROMPT_COMMANDS = frozenset({
    "doctor", "setup", "uninstall", "update", "check-update", "version",
})
\`\`\`

A unit test asserts every name in this set is still a registered CLI command — if one is renamed or removed in `cli.py`, the test fails until the allow-list is pruned. Prevents the allow-list from drifting into a dumping ground.

## Sample output

Pass:

\`\`\`
[ok]   slash-command parity         12 prompt(s) match registered CLI commands
\`\`\`

Fail (had this run before #57):

\`\`\`
[FAIL] slash-command parity         CLI command(s) without prompt under src/aidevkit/commands/: pr-create, sub-checkout, sub-merge
\`\`\`

## Implementation notes

- Command enumeration uses `typer.main.get_group(app).commands.keys()` — returns names with Typer's underscore→hyphen conversion already applied, so the check works regardless of whether a command declares an explicit name (`@app.command("pr-create", ...)`) or relies on the default (`@app.command(...)` with `def pr_create`).
- `cli.py` import is lazy (function-local) to avoid the cli ↔ doctor cycle (`cli.py` imports `doctor`).
- Prompt enumeration uses `importlib.resources.files("aidevkit.commands")` — works whether DevKit is installed from source, wheel, or `uv tool`.

## Test plan

- [x] Three new tests in `test_doctor.py` (missing-prompt failure, orphan-prompt failure, allow-list-sync unit test)
- [x] `uv run pytest` — 435 passed, 0 failures
- [x] `ruff check src/aidevkit/doctor.py tests/test_doctor.py` — clean
- [x] Live `devkit doctor` against real environment shows the new `[ok]` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)